### PR TITLE
fix: update Cal.com API version and BookingResponse field names

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,7 @@ CALCOM_API_KEY=
 
 # Cal.com API version header
 # Check Cal.com API docs for the latest version
-CAL_API_VERSION=2024-06-14
+CAL_API_VERSION=2024-08-13
 
 # Admin Configuration (Required)
 # Your Telegram user ID for admin access and approval notifications

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
 
     # Cal.com API Configuration (Required)
     calcom_api_key: str
-    cal_api_version: str = "2024-06-14"
+    cal_api_version: str = "2024-08-13"
 
     # Admin Configuration (Required)
     admin_telegram_id: int

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -475,8 +475,8 @@ def slot_to_utc(time_iso: str) -> str:
 
 def _format_duration(booking: BookingResponse) -> str:
     """Derive human-readable duration from booking start/end times."""
-    start = datetime.fromisoformat(booking.startTime)
-    end = datetime.fromisoformat(booking.endTime)
+    start = datetime.fromisoformat(booking.start)
+    end = datetime.fromisoformat(booking.end)
     minutes = int((end - start).total_seconds() // 60)
     if minutes >= 60 and minutes % 60 == 0:
         hours = minutes // 60

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -60,8 +60,8 @@ class BookingResponse(BaseModel):
     id: int
     uid: str
     title: str
-    startTime: str
-    endTime: str
+    start: str
+    end: str
     status: str
 
 

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -520,8 +520,8 @@ class TestConfirmBooking:
             id=1,
             uid="abc123",
             title="Meeting with Alice",
-            startTime="2026-01-06T07:00:00Z",
-            endTime="2026-01-06T08:00:00Z",
+            start="2026-01-06T07:00:00Z",
+            end="2026-01-06T08:00:00Z",
             status="accepted",
         )
 
@@ -671,8 +671,8 @@ class TestConfirmBooking:
             id=1,
             uid="abc123",
             title="Meeting",
-            startTime="2026-01-06T07:00:00Z",
-            endTime="2026-01-06T07:30:00Z",
+            start="2026-01-06T07:00:00Z",
+            end="2026-01-06T07:30:00Z",
             status="accepted",
         )
 
@@ -792,8 +792,8 @@ class TestFormatDuration:
     def test_one_hour(self):
         booking = BookingResponse(
             id=1, uid="x", title="T",
-            startTime="2026-01-06T07:00:00Z",
-            endTime="2026-01-06T08:00:00Z",
+            start="2026-01-06T07:00:00Z",
+            end="2026-01-06T08:00:00Z",
             status="accepted",
         )
         assert _format_duration(booking) == "1 hour"
@@ -801,8 +801,8 @@ class TestFormatDuration:
     def test_two_hours(self):
         booking = BookingResponse(
             id=1, uid="x", title="T",
-            startTime="2026-01-06T07:00:00Z",
-            endTime="2026-01-06T09:00:00Z",
+            start="2026-01-06T07:00:00Z",
+            end="2026-01-06T09:00:00Z",
             status="accepted",
         )
         assert _format_duration(booking) == "2 hours"
@@ -810,8 +810,8 @@ class TestFormatDuration:
     def test_30_minutes(self):
         booking = BookingResponse(
             id=1, uid="x", title="T",
-            startTime="2026-01-06T07:00:00Z",
-            endTime="2026-01-06T07:30:00Z",
+            start="2026-01-06T07:00:00Z",
+            end="2026-01-06T07:30:00Z",
             status="accepted",
         )
         assert _format_duration(booking) == "30 minutes"
@@ -819,8 +819,8 @@ class TestFormatDuration:
     def test_45_minutes(self):
         booking = BookingResponse(
             id=1, uid="x", title="T",
-            startTime="2026-01-06T07:00:00Z",
-            endTime="2026-01-06T07:45:00Z",
+            start="2026-01-06T07:00:00Z",
+            end="2026-01-06T07:45:00Z",
             status="accepted",
         )
         assert _format_duration(booking) == "45 minutes"

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -97,8 +97,8 @@ class TestBookingModels:
             "id": 123,
             "uid": "abc-123-def",
             "title": "Test Booking",
-            "startTime": "2026-01-01T10:00:00.000Z",
-            "endTime": "2026-01-01T11:00:00.000Z",
+            "start": "2026-01-01T10:00:00.000Z",
+            "end": "2026-01-01T11:00:00.000Z",
             "status": "accepted",
         }
         response = BookingResponse.model_validate(data)
@@ -259,8 +259,8 @@ class TestCalComClient:
                 "id": 123,
                 "uid": "abc-123",
                 "title": "Step work",
-                "startTime": "2026-01-01T10:00:00.000Z",
-                "endTime": "2026-01-01T11:00:00.000Z",
+                "start": "2026-01-01T10:00:00.000Z",
+                "end": "2026-01-01T11:00:00.000Z",
                 "status": "accepted",
             },
         }
@@ -299,8 +299,8 @@ class TestCalComClient:
                 "id": 123,
                 "uid": "abc-123",
                 "title": "Step work",
-                "startTime": "2026-01-01T10:00:00.000Z",
-                "endTime": "2026-01-01T11:00:00.000Z",
+                "start": "2026-01-01T10:00:00.000Z",
+                "end": "2026-01-01T11:00:00.000Z",
                 "status": "accepted",
             },
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ def test_config_defaults():
 
     settings = Settings()
 
-    assert settings.cal_api_version == "2024-06-14"
+    assert settings.cal_api_version == "2024-08-13"
     assert settings.calcom_event_slug == "step"
     assert settings.database_path == "telecalbot.db"
     assert settings.log_level == "INFO"


### PR DESCRIPTION
## Summary
- Update Cal.com API version from `2024-06-14` to `2024-08-13`
- Rename `BookingResponse` fields from `startTime`/`endTime` to `start`/`end` to match actual Cal.com v2 API response format

## Test plan
- [x] All 120 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)