### PR TITLE
feat: add /help command and translate messages to Russian

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -2,17 +2,17 @@
 
 # Russian timezones sorted by UTC offset
 RUSSIAN_TIMEZONES = [
-    ("Europe/Kaliningrad", "Kaliningrad (UTC+2)"),
-    ("Europe/Moscow", "Moscow (UTC+3)"),
-    ("Europe/Samara", "Samara (UTC+4)"),
-    ("Asia/Yekaterinburg", "Yekaterinburg (UTC+5)"),
-    ("Asia/Omsk", "Omsk (UTC+6)"),
-    ("Asia/Krasnoyarsk", "Krasnoyarsk (UTC+7)"),
-    ("Asia/Irkutsk", "Irkutsk (UTC+8)"),
-    ("Asia/Yakutsk", "Yakutsk (UTC+9)"),
-    ("Asia/Vladivostok", "Vladivostok (UTC+10)"),
-    ("Asia/Magadan", "Magadan (UTC+11)"),
-    ("Asia/Kamchatka", "Kamchatka (UTC+12)"),
+    ("Europe/Kaliningrad", "Калининград (UTC+2)"),
+    ("Europe/Moscow", "Москва (UTC+3)"),
+    ("Europe/Samara", "Самара (UTC+4)"),
+    ("Asia/Yekaterinburg", "Екатеринбург (UTC+5)"),
+    ("Asia/Omsk", "Омск (UTC+6)"),
+    ("Asia/Krasnoyarsk", "Красноярск (UTC+7)"),
+    ("Asia/Irkutsk", "Иркутск (UTC+8)"),
+    ("Asia/Yakutsk", "Якутск (UTC+9)"),
+    ("Asia/Vladivostok", "Владивосток (UTC+10)"),
+    ("Asia/Magadan", "Магадан (UTC+11)"),
+    ("Asia/Kamchatka", "Камчатка (UTC+12)"),
 ]
 
 # Default timezone
@@ -20,14 +20,14 @@ DEFAULT_TIMEZONE = "Europe/Moscow"
 
 # Message templates
 MESSAGES = {
-    "welcome": "Welcome! I can help you book appointments.",
+    "welcome": "Добро пожаловать! Я помогу вам записаться на встречу.",
     "access_denied": (
-        "This bot is for approved users only.\n\n"
-        "Your Chat ID: `{chat_id}`\n\n"
-        "An access request has been sent to the admin."
+        "Этот бот доступен только для одобренных пользователей.\n\n"
+        "Ваш Chat ID: `{chat_id}`\n\n"
+        "Запрос на доступ отправлен администратору."
     ),
-    "access_request_sent": "Access request sent. Please wait for admin approval.",
-    "access_approved": "You've been approved! Use /start to begin booking.",
-    "access_rejected": "Your access request was denied.",
-    "error_generic": "Sorry, something went wrong. Please try again later.",
+    "access_request_sent": "Запрос на доступ отправлен. Пожалуйста, дождитесь одобрения.",
+    "access_approved": "Вы одобрены! Используйте /start, чтобы начать запись.",
+    "access_rejected": "Ваш запрос на доступ отклонён.",
+    "error_generic": "Извините, что-то пошло не так. Попробуйте позже.",
 }

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -2,11 +2,13 @@
 
 from app.handlers.admin import approve_command, pending_command, reject_command
 from app.handlers.booking import create_booking_handler
+from app.handlers.help import help_command
 from app.handlers.start import start_command
 
 __all__ = [
     "approve_command",
     "create_booking_handler",
+    "help_command",
     "pending_command",
     "reject_command",
     "start_command",

--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -67,7 +67,7 @@ async def approve_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         try:
             await context.bot.send_message(
                 chat_id=telegram_id,
-                text="You've been approved! Use /start to begin booking.",
+                text="Вы одобрены! Используйте /start, чтобы начать запись.",
             )
         except Exception as e:
             logger.warning(f"Failed to notify user {telegram_id}: {e}")

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -46,7 +46,7 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     """Start the booking conversation with timezone selection."""
     keyboard = build_timezone_keyboard()
     await update.message.reply_text(
-        "Please select your timezone:",
+        "Выберите ваш часовой пояс:",
         reply_markup=keyboard,
     )
     return BookingState.SELECTING_TIMEZONE
@@ -76,7 +76,7 @@ async def change_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     keyboard = build_timezone_keyboard()
     await query.edit_message_text(
-        "Please select your timezone:",
+        "Выберите ваш часовой пояс:",
         reply_markup=keyboard,
     )
     return BookingState.SELECTING_TIMEZONE
@@ -91,7 +91,7 @@ async def _show_availability(
     query, context: ContextTypes.DEFAULT_TYPE, offset_days: int = 0
 ) -> int:
     """Fetch and display availability for the user's timezone."""
-    await query.edit_message_text("Fetching available times...")
+    await query.edit_message_text("Загружаю доступное время...")
 
     calcom_client: CalComClient = context.bot_data["calcom_client"]
     timezone_id = context.user_data["timezone"]
@@ -108,14 +108,14 @@ async def _show_availability(
         has_slots = any(availability.slots.values())
         if not has_slots:
             await query.edit_message_text(
-                "No available times found for this period.",
+                "Нет доступного времени на этот период.",
                 reply_markup=InlineKeyboardMarkup(
                     [
                         [
                             InlineKeyboardButton(
-                                "Change Timezone", callback_data="change_tz"
+                                "Сменить часовой пояс", callback_data="change_tz"
                             ),
-                            InlineKeyboardButton("Cancel", callback_data="cancel"),
+                            InlineKeyboardButton("Отмена", callback_data="cancel"),
                         ]
                     ]
                 ),
@@ -124,22 +124,22 @@ async def _show_availability(
 
         keyboard = build_availability_keyboard(availability.slots, offset_days)
         await query.edit_message_text(
-            f"Available times ({timezone_id}):\n\nSelect a time slot:",
+            f"Доступное время ({timezone_id}):\n\nВыберите время:",
             reply_markup=keyboard,
         )
         return BookingState.VIEWING_AVAILABILITY
 
     except CalComAPIError:
         await query.edit_message_text(
-            "Sorry, something went wrong fetching availability. Please try again.",
+            "Извините, не удалось загрузить расписание. Попробуйте ещё раз.",
             reply_markup=InlineKeyboardMarkup(
                 [
                     [
                         InlineKeyboardButton(
-                            "Try Again",
+                            "Попробовать снова",
                             callback_data=f"tz:{timezone_id}",
                         ),
-                        InlineKeyboardButton("Cancel", callback_data="cancel"),
+                        InlineKeyboardButton("Отмена", callback_data="cancel"),
                     ]
                 ]
             ),
@@ -179,7 +179,7 @@ async def select_slot(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     context.user_data["selected_date"] = parts[1]
     context.user_data["selected_time"] = parts[2]
 
-    await query.edit_message_text("Please enter your name:")
+    await query.edit_message_text("Введите ваше имя:")
     return BookingState.ENTERING_NAME
 
 
@@ -196,13 +196,13 @@ async def enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Yes, add email", callback_data="email_yes"),
-                InlineKeyboardButton("No, skip", callback_data="email_no"),
+                InlineKeyboardButton("Да, указать email", callback_data="email_yes"),
+                InlineKeyboardButton("Нет, пропустить", callback_data="email_no"),
             ]
         ]
     )
     await update.message.reply_text(
-        f"Got it, {name}! Would you like to add your email for a confirmation?",
+        f"Отлично, {name}! Хотите указать email для подтверждения?",
         reply_markup=keyboard,
     )
     return BookingState.EMAIL_DECISION
@@ -219,7 +219,7 @@ async def email_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     await query.answer()
 
     if query.data == "email_yes":
-        await query.edit_message_text("Please enter your email address:")
+        await query.edit_message_text("Введите ваш email:")
         return BookingState.ENTERING_EMAIL
     else:
         context.user_data["email"] = None
@@ -232,7 +232,7 @@ async def enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
     if "@" not in email or "." not in email.split("@")[-1]:
         await update.message.reply_text(
-            "That doesn't look like a valid email. Please try again:"
+            "Некорректный email. Попробуйте ещё раз:"
         )
         return BookingState.ENTERING_EMAIL
 
@@ -269,11 +269,11 @@ def _build_confirmation_text(data: dict) -> str:
     )
     email_line = f"\nEmail: {data['email']}" if data.get("email") else ""
     return (
-        f"Please confirm your booking:\n\n"
-        f"Time: {formatted_time}\n"
-        f"Name: {data['name']}"
+        f"Подтвердите запись:\n\n"
+        f"Время: {formatted_time}\n"
+        f"Имя: {data['name']}"
         f"{email_line}\n\n"
-        f"Tap 'Confirm Booking' to proceed."
+        f"Нажмите «Подтвердить запись» для продолжения."
     )
 
 
@@ -281,8 +281,8 @@ def _confirmation_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Confirm Booking", callback_data="confirm"),
-                InlineKeyboardButton("Cancel", callback_data="cancel"),
+                InlineKeyboardButton("Подтвердить запись", callback_data="confirm"),
+                InlineKeyboardButton("Отмена", callback_data="cancel"),
             ]
         ]
     )
@@ -298,7 +298,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     await query.answer()
 
-    await query.edit_message_text("Creating your booking...")
+    await query.edit_message_text("Создаю запись...")
 
     data = context.user_data
     calcom_client: CalComClient = context.bot_data["calcom_client"]
@@ -330,16 +330,16 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         duration = _format_duration(booking)
         email_note = (
-            f"\nA confirmation email has been sent to {email}."
+            f"\nПисьмо с подтверждением отправлено на {email}."
             if data.get("email")
             else ""
         )
 
         await query.edit_message_text(
-            f"All set! Your appointment is confirmed.\n\n"
-            f"Time: {formatted_time}\n"
-            f"Duration: {duration}\n\n"
-            f"We'll connect via Telegram at that time."
+            f"Готово! Ваша встреча подтверждена.\n\n"
+            f"Время: {formatted_time}\n"
+            f"Длительность: {duration}\n\n"
+            f"Мы свяжемся через Telegram в назначенное время."
             f"{email_note}"
         )
         return ConversationHandler.END
@@ -347,19 +347,19 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     except CalComAPIError as e:
         if e.status_code == 409:
             error_msg = (
-                "That time slot is no longer available. Please choose another time."
+                "Это время уже занято. Пожалуйста, выберите другое время."
             )
         else:
-            error_msg = "Sorry, something went wrong. Please try again."
+            error_msg = "Извините, что-то пошло не так. Попробуйте ещё раз."
 
         keyboard = InlineKeyboardMarkup(
             [
                 [
                     InlineKeyboardButton(
-                        "Choose Another Time",
+                        "Выбрать другое время",
                         callback_data=f"tz:{data['timezone']}",
                     ),
-                    InlineKeyboardButton("Cancel", callback_data="cancel"),
+                    InlineKeyboardButton("Отмена", callback_data="cancel"),
                 ]
             ]
         )
@@ -377,9 +377,9 @@ async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
     if query:
         await query.answer()
-        await query.edit_message_text("Booking cancelled.")
+        await query.edit_message_text("Запись отменена.")
     else:
-        await update.message.reply_text("Booking cancelled.")
+        await update.message.reply_text("Запись отменена.")
 
     context.user_data.clear()
     return ConversationHandler.END
@@ -396,7 +396,7 @@ def build_timezone_keyboard() -> InlineKeyboardMarkup:
         [InlineKeyboardButton(label, callback_data=f"tz:{tz_id}")]
         for tz_id, label in RUSSIAN_TIMEZONES
     ]
-    buttons.append([InlineKeyboardButton("Cancel", callback_data="cancel")])
+    buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
     return InlineKeyboardMarkup(buttons)
 
 
@@ -432,19 +432,19 @@ def build_availability_keyboard(
     if offset_days > 0:
         nav_row.append(
             InlineKeyboardButton(
-                "← Prev Dates", callback_data=f"dates:{offset_days - 5}"
+                "← Назад", callback_data=f"dates:{offset_days - 5}"
             )
         )
     nav_row.append(
         InlineKeyboardButton(
-            "More Dates →", callback_data=f"dates:{offset_days + 5}"
+            "Ещё даты →", callback_data=f"dates:{offset_days + 5}"
         )
     )
     nav_row.append(
-        InlineKeyboardButton("Change Timezone", callback_data="change_tz")
+        InlineKeyboardButton("Сменить часовой пояс", callback_data="change_tz")
     )
     buttons.append(nav_row)
-    buttons.append([InlineKeyboardButton("Cancel", callback_data="cancel")])
+    buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
 
     return InlineKeyboardMarkup(buttons)
 
@@ -480,8 +480,8 @@ def _format_duration(booking: BookingResponse) -> str:
     minutes = int((end - start).total_seconds() // 60)
     if minutes >= 60 and minutes % 60 == 0:
         hours = minutes // 60
-        return f"{hours} hour{'s' if hours != 1 else ''}"
-    return f"{minutes} minutes"
+        return f"{hours} ч."
+    return f"{minutes} мин."
 
 
 def _format_datetime_display(date_str: str, time_iso: str, tz_id: str) -> str:

--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -1,0 +1,38 @@
+"""Handler for the /help command."""
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from app.config import settings
+from app.services.whitelist import WhitelistService
+
+logger = logging.getLogger(__name__)
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Show available commands based on user's access level."""
+    whitelist_service: WhitelistService = context.bot_data["whitelist_service"]
+    user_id = update.effective_user.id
+
+    if not whitelist_service.is_whitelisted(user_id):
+        await update.message.reply_text(
+            "Доступные команды:\n\n"
+            "/start — Запросить доступ к боту"
+        )
+        return
+
+    lines = [
+        "Доступные команды:\n",
+        "/book — Записаться на встречу",
+        "/help — Показать список команд",
+    ]
+
+    if user_id == settings.admin_telegram_id:
+        lines.append("\nAdmin commands:\n")
+        lines.append("/approve <id> — Approve access request")
+        lines.append("/reject <id> — Reject access request")
+        lines.append("/pending — List pending access requests")
+
+    await update.message.reply_text("\n".join(lines))

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -33,7 +33,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if whitelist_service.is_whitelisted(chat_id):
         # Whitelisted user - show main menu
         await update.message.reply_text(
-            f"Welcome, {user.first_name}! I can help you book appointments."
+            f"Добро пожаловать, {user.first_name}! Я помогу вам записаться на встречу."
         )
     else:
         # Not whitelisted - create access request and notify admin
@@ -48,9 +48,9 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             await _notify_admin_of_request(context, user)
 
         await update.message.reply_text(
-            f"This bot is for approved users only.\n\n"
-            f"Your Chat ID: `{chat_id}`\n\n"
-            f"An access request has been sent to the admin.",
+            f"Этот бот доступен только для одобренных пользователей.\n\n"
+            f"Ваш Chat ID: `{chat_id}`\n\n"
+            f"Запрос на доступ отправлен администратору.",
             parse_mode="Markdown",
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.database import db, run_migrations
 from app.handlers import (
     approve_command,
     create_booking_handler,
+    help_command,
     pending_command,
     reject_command,
     start_command,
@@ -55,6 +56,7 @@ def main() -> None:
     application.add_handler(CommandHandler("approve", approve_command))
     application.add_handler(CommandHandler("reject", reject_command))
     application.add_handler(CommandHandler("pending", pending_command))
+    application.add_handler(CommandHandler("help", help_command))
     application.add_handler(create_booking_handler())
 
     logger.info("Bot started. Press Ctrl+C to stop.")

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -166,7 +166,7 @@ class TestBuildTimezoneKeyboard:
         keyboard = build_timezone_keyboard()
         all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
         labels = [btn.text for btn in all_buttons]
-        assert "Cancel" in labels
+        assert "Отмена" in labels
 
     def test_callback_data_uses_tz_prefix(self):
         keyboard = build_timezone_keyboard()
@@ -196,13 +196,13 @@ class TestBuildAvailabilityKeyboard:
         keyboard = build_availability_keyboard(availability_response.slots)
         all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
         labels = [btn.text for btn in all_buttons]
-        assert any("More" in lbl for lbl in labels)
+        assert any("→" in lbl for lbl in labels)
 
     def test_has_cancel_button(self, availability_response):
         keyboard = build_availability_keyboard(availability_response.slots)
         all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
         labels = [btn.text for btn in all_buttons]
-        assert "Cancel" in labels
+        assert "Отмена" in labels
 
     def test_max_6_slots_per_day(self):
         many_slots = AvailabilityResponse(
@@ -305,7 +305,7 @@ class TestSelectTimezone:
         assert result == BookingState.VIEWING_AVAILABILITY
         # Error message shown
         last_call = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
-        assert "wrong" in last_call.lower() or "sorry" in last_call.lower()
+        assert "извините" in last_call.lower() or "не удалось" in last_call.lower()
 
 
 class TestSelectSlot:
@@ -337,7 +337,7 @@ class TestSelectSlot:
 
         mock_update_with_query.callback_query.edit_message_text.assert_called_once()
         prompt = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
-        assert "name" in prompt.lower()
+        assert "имя" in prompt.lower()
 
 
 class TestEnterName:
@@ -500,7 +500,7 @@ class TestEnterEmail:
 
         mock_update.message.reply_text.assert_called_once()
         msg = mock_update.message.reply_text.call_args[0][0]
-        assert "valid" in msg.lower() or "try again" in msg.lower()
+        assert "некорректный" in msg.lower() or "ещё раз" in msg.lower()
 
 
 class TestConfirmBooking:
@@ -589,7 +589,7 @@ class TestConfirmBooking:
             await confirm_booking(mock_update_with_query, mock_context)
 
         final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
-        assert "confirmed" in final_message.lower() or "set" in final_message.lower()
+        assert "подтверждена" in final_message.lower() or "готово" in final_message.lower()
 
     @pytest.mark.asyncio
     async def test_uses_placeholder_email_when_none(
@@ -636,7 +636,7 @@ class TestConfirmBooking:
 
         assert result == BookingState.VIEWING_AVAILABILITY
         error_msg = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
-        assert "available" in error_msg.lower() or "another" in error_msg.lower()
+        assert "занято" in error_msg.lower() or "другое" in error_msg.lower()
 
     @pytest.mark.asyncio
     async def test_handles_generic_api_error(
@@ -681,7 +681,7 @@ class TestConfirmBooking:
             await confirm_booking(mock_update_with_query, mock_context)
 
         final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
-        assert "30 minutes" in final_message
+        assert "30 мин." in final_message
 
     @pytest.mark.asyncio
     async def test_shows_timezone_in_confirmation(
@@ -737,7 +737,7 @@ class TestCancel:
 
         mock_update_with_query.callback_query.edit_message_text.assert_called_once()
         msg = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
-        assert "cancel" in msg.lower()
+        assert "отменена" in msg.lower()
 
 
 class TestLoadMoreDates:
@@ -796,7 +796,7 @@ class TestFormatDuration:
             end="2026-01-06T08:00:00Z",
             status="accepted",
         )
-        assert _format_duration(booking) == "1 hour"
+        assert _format_duration(booking) == "1 ч."
 
     def test_two_hours(self):
         booking = BookingResponse(
@@ -805,7 +805,7 @@ class TestFormatDuration:
             end="2026-01-06T09:00:00Z",
             status="accepted",
         )
-        assert _format_duration(booking) == "2 hours"
+        assert _format_duration(booking) == "2 ч."
 
     def test_30_minutes(self):
         booking = BookingResponse(
@@ -814,7 +814,7 @@ class TestFormatDuration:
             end="2026-01-06T07:30:00Z",
             status="accepted",
         )
-        assert _format_duration(booking) == "30 minutes"
+        assert _format_duration(booking) == "30 мин."
 
     def test_45_minutes(self):
         booking = BookingResponse(
@@ -823,4 +823,4 @@ class TestFormatDuration:
             end="2026-01-06T07:45:00Z",
             status="accepted",
         )
-        assert _format_duration(booking) == "45 minutes"
+        assert _format_duration(booking) == "45 мин."

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,118 @@
+"""Tests for /help command handler."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.database import Database
+from app.database.migrations import initialize_schema
+from app.handlers.help import help_command
+from app.services.whitelist import WhitelistService
+
+
+@pytest.fixture
+def whitelist_service(temp_db_path):
+    """Create a WhitelistService with a test database."""
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    return WhitelistService(db)
+
+
+@pytest.fixture
+def mock_update():
+    """Create a mock Update object."""
+    update = MagicMock()
+    update.effective_user = MagicMock()
+    update.effective_user.id = 12345
+    update.effective_user.first_name = "Test"
+    update.effective_user.username = "testuser"
+    update.message = AsyncMock()
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+@pytest.fixture
+def mock_context(whitelist_service):
+    """Create a mock Context object with injected services."""
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.bot_data = {"whitelist_service": whitelist_service}
+    return context
+
+
+class TestHelpCommand:
+    """Tests for /help command."""
+
+    @pytest.mark.asyncio
+    async def test_whitelisted_user_sees_available_commands(
+        self, mock_update, mock_context, whitelist_service
+    ):
+        """Whitelisted user sees /book and /help commands."""
+        whitelist_service.add_to_whitelist(
+            telegram_id=12345,
+            display_name="Test",
+            username="testuser",
+            approved_by=789,
+        )
+
+        await help_command(mock_update, mock_context)
+
+        response = mock_update.message.reply_text.call_args[0][0]
+        assert "/book" in response
+        assert "/help" in response
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_user_sees_minimal_message(
+        self, mock_update, mock_context
+    ):
+        """Non-whitelisted user sees only /start."""
+        await help_command(mock_update, mock_context)
+
+        response = mock_update.message.reply_text.call_args[0][0]
+        assert "/start" in response
+        # Should NOT see /book
+        assert "/book" not in response
+
+    @pytest.mark.asyncio
+    async def test_admin_sees_admin_commands(
+        self, mock_update, mock_context, whitelist_service
+    ):
+        """Admin user sees admin commands in addition to regular ones."""
+        whitelist_service.add_to_whitelist(
+            telegram_id=12345,
+            display_name="Test",
+            username="testuser",
+            approved_by=789,
+        )
+
+        with patch("app.handlers.help.settings") as mock_settings:
+            mock_settings.admin_telegram_id = 12345
+
+            await help_command(mock_update, mock_context)
+
+        response = mock_update.message.reply_text.call_args[0][0]
+        assert "/approve" in response
+        assert "/reject" in response
+        assert "/pending" in response
+
+    @pytest.mark.asyncio
+    async def test_non_admin_does_not_see_admin_commands(
+        self, mock_update, mock_context, whitelist_service
+    ):
+        """Regular whitelisted user does NOT see admin commands."""
+        whitelist_service.add_to_whitelist(
+            telegram_id=12345,
+            display_name="Test",
+            username="testuser",
+            approved_by=789,
+        )
+
+        with patch("app.handlers.help.settings") as mock_settings:
+            mock_settings.admin_telegram_id = 99999
+
+            await help_command(mock_update, mock_context)
+
+        response = mock_update.message.reply_text.call_args[0][0]
+        assert "/approve" not in response
+        assert "/reject" not in response
+        assert "/pending" not in response

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -61,7 +61,7 @@ class TestStartCommandAccessControl:
 
         mock_update.message.reply_text.assert_called_once()
         response = mock_update.message.reply_text.call_args[0][0]
-        assert "welcome" in response.lower() or "book" in response.lower()
+        assert "добро пожаловать" in response.lower() or "записаться" in response.lower()
 
     @pytest.mark.asyncio
     async def test_non_whitelisted_user_sees_access_denied(
@@ -74,7 +74,7 @@ class TestStartCommandAccessControl:
         response = mock_update.message.reply_text.call_args[0][0]
 
         # Should mention access denied / approved users only
-        assert "approved" in response.lower() or "access" in response.lower()
+        assert "одобренных" in response.lower() or "доступ" in response.lower()
         # Should include chat ID
         assert "12345" in response
 
@@ -159,4 +159,4 @@ class TestStartCommandAccessControl:
 
         # Should see welcome, not access denied
         response = mock_update.message.reply_text.call_args[0][0]
-        assert "approved" not in response.lower() or "welcome" in response.lower()
+        assert "одобренных" not in response.lower() or "добро пожаловать" in response.lower()


### PR DESCRIPTION
## Summary
- Add `/help` command with role-based output: admin sees admin commands, regular users see `/book` and `/help`, non-whitelisted users see only `/start`
- Translate all user-facing bot messages to Russian (timezone labels, booking flow, start/access messages, error messages)
- Admin commands (`/approve`, `/reject`, `/pending`) and admin notifications remain in English

Closes #18, closes #19

## Test plan
- [x] All 124 tests pass (4 new tests for /help, 16 existing tests updated for Russian text)
- [x] Linter passes
- [ ] Manual: verify /help shows correct commands per role
- [ ] Manual: verify all bot messages display in Russian

🤖 Generated with [Claude Code](https://claude.com/claude-code)