### PR TITLE
fix: onboarding fallback + Russian booking UI text

### DIFF
--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -3,7 +3,7 @@
 from app.handlers.admin import approve_command, pending_command, reject_command
 from app.handlers.booking import create_booking_handler
 from app.handlers.help import help_command
-from app.handlers.start import start_command
+from app.handlers.start import start_command, text_onboarding_or_help
 
 __all__ = [
     "approve_command",
@@ -12,4 +12,5 @@ __all__ = [
     "pending_command",
     "reject_command",
     "start_command",
+    "text_onboarding_or_help",
 ]

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -52,7 +52,7 @@ RUSSIAN_MONTHS_ABBR = [
     "дек",
 ]
 
-TIMEZONE_BUTTON_LABEL = "Часовой пояс ⚙️"
+TIMEZONE_BUTTON_LABEL = "Часовой пояс"
 
 
 class BookingState(IntEnum):
@@ -489,10 +489,10 @@ def build_availability_keyboard(
             "Ещё даты →", callback_data=f"dates:{offset_days + 5}"
         )
     )
-    nav_row.append(
-        InlineKeyboardButton(TIMEZONE_BUTTON_LABEL, callback_data="change_tz")
-    )
     buttons.append(nav_row)
+    buttons.append(
+        [InlineKeyboardButton(TIMEZONE_BUTTON_LABEL, callback_data="change_tz")]
+    )
     buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
 
     return InlineKeyboardMarkup(buttons)
@@ -538,7 +538,10 @@ def _format_duration(booking: BookingResponse) -> str:
 def _format_datetime_display(date_str: str, time_iso: str, tz_id: str) -> str:
     """Format date and time for user-facing display."""
     dt = datetime.fromisoformat(time_iso)
-    return f"{dt.strftime('%A, %B %-d at %-I:%M %p')} ({tz_id})"
+    weekday = RUSSIAN_WEEKDAYS[dt.weekday()]
+    month_abbr = RUSSIAN_MONTHS_ABBR[dt.month - 1]
+    time_value = dt.strftime("%H:%M")
+    return f"{weekday}, {dt.day} {month_abbr} в {time_value} ({tz_id})"
 
 
 # ---------------------------------------------------------------------------

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -57,6 +57,22 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         )
 
 
+async def text_onboarding_or_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle plain-text messages outside commands/conversations.
+
+    - Whitelisted users see help immediately.
+    - New users get the same access-request flow as /start.
+    """
+    whitelist_service: WhitelistService = context.bot_data["whitelist_service"]
+    user_id = update.effective_user.id
+
+    if whitelist_service.is_whitelisted(user_id):
+        await help_command(update, context)
+        return
+
+    await start_command(update, context)
+
+
 async def _notify_admin_of_request(context: ContextTypes.DEFAULT_TYPE, user) -> None:
     """Send notification to admin about new access request."""
     username_str = f"@{user.username}" if user.username else "(no username)"

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 
-from telegram.ext import Application, CommandHandler
+from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
 from app.config import settings
 from app.database import db, run_migrations
@@ -14,6 +14,7 @@ from app.handlers import (
     pending_command,
     reject_command,
     start_command,
+    text_onboarding_or_help,
 )
 from app.services.calcom_client import CalComClient
 from app.services.whitelist import WhitelistService
@@ -58,6 +59,9 @@ def main() -> None:
     application.add_handler(CommandHandler("pending", pending_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(create_booking_handler())
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, text_onboarding_or_help)
+    )
 
     logger.info("Bot started. Press Ctrl+C to stop.")
 


### PR DESCRIPTION
## Summary
- add a plain-text fallback handler so users get onboarding/help even if they do not send a command (fixes blank first-open behavior)
- move timezone button to its own row and shorten label to avoid truncation in slot selection
- format booking confirmation date/time in Russian
- add/update tests for fallback onboarding, timezone button layout, and Russian confirmation text

## Testing
- uv run pytest tests/test_start.py tests/test_help.py tests/test_booking.py -q
- uv run pytest -q

Closes #32
Closes #30
Closes #31