### PR TITLE
Remove stale AVAILABILITY_CACHE_TTL from .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,10 +34,6 @@ DATABASE_PATH=telecalbot.db
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO
 
-# Bot behavior
-# Time to cache availability data (in seconds)
-AVAILABILITY_CACHE_TTL=300
-
 # Claude Code Configuration (Optional)
 # Returns to project root after every command
 CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=true


### PR DESCRIPTION
## Summary
- Remove deprecated AVAILABILITY_CACHE_TTL entry from .env.sample
- Keep sample env config aligned with runtime settings in app/config.py

Closes #22

## Verification
- uv run pytest tests/test_config.py -q -> 3 passed
- uv run pytest -q -> 135 passed