### PR TITLE
Add name validation in booking flow

### DIFF
--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -53,6 +53,7 @@ RUSSIAN_MONTHS_ABBR = [
 ]
 
 TIMEZONE_BUTTON_LABEL = "Часовой пояс"
+MAX_NAME_LENGTH = 100
 
 
 class BookingState(IntEnum):
@@ -239,6 +240,18 @@ async def select_slot(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 async def enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Store user's name and ask about email."""
     name = update.message.text.strip()
+
+    if not name:
+        await update.message.reply_text("Имя не может быть пустым. Введите ваше имя:")
+        return BookingState.ENTERING_NAME
+
+    if len(name) > MAX_NAME_LENGTH:
+        await update.message.reply_text(
+            f"Имя слишком длинное (максимум {MAX_NAME_LENGTH} символов). "
+            "Введите более короткое имя:"
+        )
+        return BookingState.ENTERING_NAME
+
     context.user_data["name"] = name
 
     keyboard = InlineKeyboardMarkup(

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -409,6 +409,30 @@ class TestEnterName:
         call_kwargs = mock_update.message.reply_text.call_args[1]
         assert "reply_markup" in call_kwargs
 
+    @pytest.mark.asyncio
+    async def test_rejects_empty_name(self, mock_update, mock_context):
+        mock_update.message.text = "   "
+
+        result = await enter_name(mock_update, mock_context)
+
+        assert result == BookingState.ENTERING_NAME
+        assert "name" not in mock_context.user_data
+        mock_update.message.reply_text.assert_called_once()
+        msg = mock_update.message.reply_text.call_args[0][0]
+        assert "не может быть пустым" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_too_long_name(self, mock_update, mock_context):
+        mock_update.message.text = "A" * 101
+
+        result = await enter_name(mock_update, mock_context)
+
+        assert result == BookingState.ENTERING_NAME
+        assert "name" not in mock_context.user_data
+        mock_update.message.reply_text.assert_called_once()
+        msg = mock_update.message.reply_text.call_args[0][0]
+        assert "слишком длин" in msg.lower()
+
 
 class TestEmailDecision:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add validation for booking name input in `enter_name`
- Reject empty names after trimming whitespace
- Reject overlong names (>100 chars)
- Keep user in the name-entry step with a clear error message
- Add tests for empty and overlong name cases

Closes #24

## Verification
- uv run pytest tests/test_booking.py -q -> 66 passed
- uv run pytest -q -> 137 passed