### PR TITLE
Add /cancel_booking command with confirmation flow

### DIFF
--- a/app/database/migrations.py
+++ b/app/database/migrations.py
@@ -31,6 +31,24 @@ CREATE TABLE IF NOT EXISTS user_preferences (
     timezone TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
+
+-- Persisted bookings for /cancel_booking flow
+CREATE TABLE IF NOT EXISTS bookings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    telegram_id INTEGER NOT NULL,
+    calcom_booking_id INTEGER NOT NULL,
+    calcom_booking_uid TEXT NOT NULL,
+    title TEXT NOT NULL,
+    start TEXT NOT NULL,
+    "end" TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'cancelled')),
+    created_at TEXT NOT NULL,
+    cancelled_at TEXT,
+    UNIQUE(telegram_id, calcom_booking_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bookings_user_status_start
+ON bookings(telegram_id, status, start);
 """
 
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -31,3 +31,18 @@ class UserPreference(BaseModel):
     telegram_id: int
     timezone: str
     updated_at: datetime
+
+
+class StoredBooking(BaseModel):
+    """Booking record persisted for cancellation lookup."""
+
+    id: int
+    telegram_id: int
+    calcom_booking_id: int
+    calcom_booking_uid: str
+    title: str
+    start: datetime
+    end: datetime
+    status: str
+    created_at: datetime
+    cancelled_at: datetime | None = None

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -1,14 +1,17 @@
 """Telegram bot handlers."""
 
 from app.handlers.admin import approve_command, pending_command, reject_command
-from app.handlers.booking import create_booking_handler, create_cancel_booking_handlers
+from app.handlers.booking import (
+    create_booking_conversation_handler,
+    create_cancel_booking_flow_handlers,
+)
 from app.handlers.help import help_command
 from app.handlers.start import start_command, text_onboarding_or_help
 
 __all__ = [
     "approve_command",
-    "create_booking_handler",
-    "create_cancel_booking_handlers",
+    "create_booking_conversation_handler",
+    "create_cancel_booking_flow_handlers",
     "help_command",
     "pending_command",
     "reject_command",

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -1,13 +1,14 @@
 """Telegram bot handlers."""
 
 from app.handlers.admin import approve_command, pending_command, reject_command
-from app.handlers.booking import create_booking_handler
+from app.handlers.booking import create_booking_handler, create_cancel_booking_handlers
 from app.handlers.help import help_command
 from app.handlers.start import start_command, text_onboarding_or_help
 
 __all__ = [
     "approve_command",
     "create_booking_handler",
+    "create_cancel_booking_handlers",
     "help_command",
     "pending_command",
     "reject_command",

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -615,7 +615,7 @@ async def cancel_booking_back(update: Update, context: ContextTypes.DEFAULT_TYPE
     )
 
 
-def create_cancel_booking_handlers() -> list:
+def create_cancel_booking_flow_handlers() -> list:
     """Create handlers for /cancel_booking flow."""
     return [
         CommandHandler("cancel_booking", cancel_booking_command),
@@ -788,7 +788,7 @@ def _format_stored_booking_summary(booking) -> str:
 # ---------------------------------------------------------------------------
 
 
-def create_booking_handler() -> ConversationHandler:
+def create_booking_conversation_handler() -> ConversationHandler:
     """Create and return the booking ConversationHandler."""
     return ConversationHandler(
         entry_points=[CommandHandler("book", book_command)],

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -18,6 +18,7 @@ from telegram.ext import (
 
 from app.config import settings
 from app.constants import RUSSIAN_TIMEZONES
+from app.services.booking_service import BookingService
 from app.services.calcom_client import (
     Attendee,
     BookingRequest,
@@ -25,7 +26,6 @@ from app.services.calcom_client import (
     CalComAPIError,
     CalComClient,
 )
-from app.services.booking_service import BookingService
 from app.services.whitelist import WhitelistService
 
 logger = logging.getLogger(__name__)
@@ -60,6 +60,11 @@ MAX_NAME_LENGTH = 100
 CANCEL_SELECT_PREFIX = "cancel_booking_select:"
 CANCEL_CONFIRM_PREFIX = "cancel_booking_confirm:"
 CANCEL_BACK_CALLBACK = "cancel_booking_back"
+CANCEL_BOOKING_TERMINAL_STATUS_CODES = {404, 409}
+CANCEL_BOOKING_ACCESS_DENIED_TEXT = (
+    "Эта команда доступна только одобренным пользователям.\n"
+    "Используйте /start для запроса доступа."
+)
 
 
 class BookingState(IntEnum):
@@ -493,15 +498,11 @@ async def booking_timeout(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 async def cancel_booking_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Show user bookings and let them choose one for cancellation."""
-    whitelist_service: WhitelistService = context.bot_data["whitelist_service"]
     booking_service: BookingService = context.bot_data["booking_service"]
     user_id = update.effective_user.id
 
-    if not whitelist_service.is_whitelisted(user_id):
-        await update.message.reply_text(
-            "Эта команда доступна только одобренным пользователям.\n"
-            "Используйте /start для запроса доступа."
-        )
+    if not _user_can_use_cancel_booking_flow(context, user_id):
+        await _deny_cancel_booking_flow_access(update)
         return
 
     bookings = booking_service.list_upcoming_bookings(user_id)
@@ -520,8 +521,12 @@ async def cancel_booking_select(update: Update, context: ContextTypes.DEFAULT_TY
     query = update.callback_query
     await query.answer()
 
-    booking_service: BookingService = context.bot_data["booking_service"]
     user_id = update.effective_user.id
+    if not _user_can_use_cancel_booking_flow(context, user_id):
+        await _deny_cancel_booking_flow_access(update)
+        return
+
+    booking_service: BookingService = context.bot_data["booking_service"]
     booking_row_id = _parse_booking_row_id(query.data, CANCEL_SELECT_PREFIX)
     if booking_row_id is None:
         await _safe_edit_message_text(query, "Некорректный выбор записи.")
@@ -562,9 +567,13 @@ async def cancel_booking_confirm(update: Update, context: ContextTypes.DEFAULT_T
     query = update.callback_query
     await query.answer()
 
+    user_id = update.effective_user.id
+    if not _user_can_use_cancel_booking_flow(context, user_id):
+        await _deny_cancel_booking_flow_access(update)
+        return
+
     booking_service: BookingService = context.bot_data["booking_service"]
     calcom_client: CalComClient = context.bot_data["calcom_client"]
-    user_id = update.effective_user.id
     booking_row_id = _parse_booking_row_id(query.data, CANCEL_CONFIRM_PREFIX)
     if booking_row_id is None:
         await _safe_edit_message_text(query, "Некорректный выбор записи.")
@@ -579,7 +588,18 @@ async def cancel_booking_confirm(update: Update, context: ContextTypes.DEFAULT_T
 
     try:
         await calcom_client.cancel_booking(booking.calcom_booking_id)
-    except CalComAPIError:
+    except CalComAPIError as error:
+        if error.status_code in CANCEL_BOOKING_TERMINAL_STATUS_CODES:
+            booking_service.mark_cancelled(booking_row_id, user_id)
+            await _safe_edit_message_text(
+                query,
+                (
+                    "Запись уже была отменена.\n\n"
+                    f"{_format_stored_booking_summary(booking)}"
+                ),
+            )
+            return
+
         await _safe_edit_message_text(
             query,
             "Не удалось отменить запись. Попробуйте позже.",
@@ -601,8 +621,12 @@ async def cancel_booking_back(update: Update, context: ContextTypes.DEFAULT_TYPE
     query = update.callback_query
     await query.answer()
 
-    booking_service: BookingService = context.bot_data["booking_service"]
     user_id = update.effective_user.id
+    if not _user_can_use_cancel_booking_flow(context, user_id):
+        await _deny_cancel_booking_flow_access(update)
+        return
+
+    booking_service: BookingService = context.bot_data["booking_service"]
     bookings = booking_service.list_upcoming_bookings(user_id)
     if not bookings:
         await _safe_edit_message_text(query, "У вас нет предстоящих записей для отмены.")
@@ -766,6 +790,27 @@ def _parse_booking_row_id(callback_data: str, prefix: str) -> int | None:
         return int(callback_data[len(prefix):])
     except ValueError:
         return None
+
+
+def _user_can_use_cancel_booking_flow(
+    context: ContextTypes.DEFAULT_TYPE,
+    user_id: int,
+) -> bool:
+    whitelist_service: WhitelistService | None = context.bot_data.get("whitelist_service")
+    if whitelist_service is None:
+        logger.error("Whitelist service is missing in bot_data; denying cancel booking flow")
+        return False
+    return whitelist_service.is_whitelisted(user_id)
+
+
+async def _deny_cancel_booking_flow_access(update: Update) -> None:
+    query = update.callback_query
+    if query:
+        await _safe_edit_message_text(query, CANCEL_BOOKING_ACCESS_DENIED_TEXT)
+        return
+
+    if update.message:
+        await update.message.reply_text(CANCEL_BOOKING_ACCESS_DENIED_TEXT)
 
 
 def _format_stored_booking_button_text(booking) -> str:

--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -26,6 +26,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     lines = [
         "Доступные команды:\n",
         "/book — Записаться на встречу",
+        "/cancel_booking — Отменить существующую запись",
         "/help — Показать список команд",
     ]
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,8 +9,8 @@ from app.config import settings
 from app.database import db, run_migrations
 from app.handlers import (
     approve_command,
-    create_booking_handler,
-    create_cancel_booking_handlers,
+    create_booking_conversation_handler,
+    create_cancel_booking_flow_handlers,
     help_command,
     pending_command,
     reject_command,
@@ -61,8 +61,8 @@ def main() -> None:
     application.add_handler(CommandHandler("reject", reject_command))
     application.add_handler(CommandHandler("pending", pending_command))
     application.add_handler(CommandHandler("help", help_command))
-    application.add_handler(create_booking_handler())
-    for handler in create_cancel_booking_handlers():
+    application.add_handler(create_booking_conversation_handler())
+    for handler in create_cancel_booking_flow_handlers():
         application.add_handler(handler)
     application.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, text_onboarding_or_help)

--- a/app/main.py
+++ b/app/main.py
@@ -10,12 +10,14 @@ from app.database import db, run_migrations
 from app.handlers import (
     approve_command,
     create_booking_handler,
+    create_cancel_booking_handlers,
     help_command,
     pending_command,
     reject_command,
     start_command,
     text_onboarding_or_help,
 )
+from app.services.booking_service import BookingService
 from app.services.calcom_client import CalComClient
 from app.services.whitelist import WhitelistService
 
@@ -47,6 +49,7 @@ def main() -> None:
 
     # Inject services
     application.bot_data["whitelist_service"] = WhitelistService(db)
+    application.bot_data["booking_service"] = BookingService(db)
     application.bot_data["calcom_client"] = CalComClient(
         api_key=settings.calcom_api_key,
         api_version=settings.cal_api_version,
@@ -59,6 +62,8 @@ def main() -> None:
     application.add_handler(CommandHandler("pending", pending_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(create_booking_handler())
+    for handler in create_cancel_booking_handlers():
+        application.add_handler(handler)
     application.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, text_onboarding_or_help)
     )

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -28,8 +28,8 @@ class BookingService:
                 calcom_booking_id,
                 calcom_booking_uid,
                 title,
-                start,
-                "end",
+                start_at,
+                end_at,
                 status,
                 created_at,
                 cancelled_at
@@ -38,8 +38,8 @@ class BookingService:
             ON CONFLICT(telegram_id, calcom_booking_id) DO UPDATE SET
                 calcom_booking_uid = excluded.calcom_booking_uid,
                 title = excluded.title,
-                start = excluded.start,
-                "end" = excluded."end",
+                start_at = excluded.start_at,
+                end_at = excluded.end_at,
                 status = 'active',
                 cancelled_at = NULL
             """,
@@ -71,7 +71,7 @@ class BookingService:
             SELECT *
             FROM bookings
             WHERE telegram_id = ? AND status = 'active'
-            ORDER BY start
+            ORDER BY start_at
             """,
             (telegram_id,),
         )
@@ -113,8 +113,8 @@ class BookingService:
             calcom_booking_id=row["calcom_booking_id"],
             calcom_booking_uid=row["calcom_booking_uid"],
             title=row["title"],
-            start=_parse_iso_datetime(row["start"]),
-            end=_parse_iso_datetime(row["end"]),
+            start=_parse_iso_datetime(row["start_at"]),
+            end=_parse_iso_datetime(row["end_at"]),
             status=row["status"],
             created_at=_parse_iso_datetime(row["created_at"]),
             cancelled_at=_parse_iso_datetime(row["cancelled_at"])

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -1,0 +1,123 @@
+"""Service for storing and retrieving user bookings."""
+
+from datetime import datetime, timezone
+
+from app.database import Database
+from app.database.models import StoredBooking
+from app.services.calcom_client import BookingResponse
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO datetime strings, accepting UTC Z suffix."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+class BookingService:
+    """Persist booking records used by /cancel_booking flow."""
+
+    def __init__(self, db: Database):
+        self.db = db
+
+    def save_booking(self, telegram_id: int, booking: BookingResponse) -> int:
+        """Insert or refresh an active booking record for a user."""
+        now = datetime.now(timezone.utc).isoformat()
+        self.db.execute_write(
+            """
+            INSERT INTO bookings (
+                telegram_id,
+                calcom_booking_id,
+                calcom_booking_uid,
+                title,
+                start,
+                "end",
+                status,
+                created_at,
+                cancelled_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, 'active', ?, NULL)
+            ON CONFLICT(telegram_id, calcom_booking_id) DO UPDATE SET
+                calcom_booking_uid = excluded.calcom_booking_uid,
+                title = excluded.title,
+                start = excluded.start,
+                "end" = excluded."end",
+                status = 'active',
+                cancelled_at = NULL
+            """,
+            (
+                telegram_id,
+                booking.id,
+                booking.uid,
+                booking.title,
+                booking.start,
+                booking.end,
+                now,
+            ),
+        )
+        row = self.db.execute_one(
+            """
+            SELECT id
+            FROM bookings
+            WHERE telegram_id = ? AND calcom_booking_id = ?
+            """,
+            (telegram_id, booking.id),
+        )
+        return row["id"]
+
+    def list_upcoming_bookings(self, telegram_id: int) -> list[StoredBooking]:
+        """Return active bookings that haven't ended yet."""
+        now = datetime.now(timezone.utc)
+        rows = self.db.execute(
+            """
+            SELECT *
+            FROM bookings
+            WHERE telegram_id = ? AND status = 'active'
+            ORDER BY start
+            """,
+            (telegram_id,),
+        )
+        bookings = [self._row_to_booking(row) for row in rows]
+        return [booking for booking in bookings if booking.end >= now]
+
+    def get_booking_for_user(self, booking_row_id: int, telegram_id: int) -> StoredBooking | None:
+        """Get a single booking owned by a user."""
+        row = self.db.execute_one(
+            """
+            SELECT *
+            FROM bookings
+            WHERE id = ? AND telegram_id = ?
+            """,
+            (booking_row_id, telegram_id),
+        )
+        if row is None:
+            return None
+        return self._row_to_booking(row)
+
+    def mark_cancelled(self, booking_row_id: int, telegram_id: int) -> bool:
+        """Mark an active booking as cancelled."""
+        cancelled_at = datetime.now(timezone.utc).isoformat()
+        rowcount = self.db.execute_write(
+            """
+            UPDATE bookings
+            SET status = 'cancelled', cancelled_at = ?
+            WHERE id = ? AND telegram_id = ? AND status = 'active'
+            """,
+            (cancelled_at, booking_row_id, telegram_id),
+        )
+        return rowcount > 0
+
+    @staticmethod
+    def _row_to_booking(row) -> StoredBooking:
+        return StoredBooking(
+            id=row["id"],
+            telegram_id=row["telegram_id"],
+            calcom_booking_id=row["calcom_booking_id"],
+            calcom_booking_uid=row["calcom_booking_uid"],
+            title=row["title"],
+            start=_parse_iso_datetime(row["start"]),
+            end=_parse_iso_datetime(row["end"]),
+            status=row["status"],
+            created_at=_parse_iso_datetime(row["created_at"]),
+            cancelled_at=_parse_iso_datetime(row["cancelled_at"])
+            if row["cancelled_at"]
+            else None,
+        )

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -183,6 +183,17 @@ class CalComClient:
 
         return BookingResponse.model_validate(response["data"])
 
+    async def cancel_booking(self, booking_id: int | str) -> None:
+        """Cancel an existing booking by Cal.com booking identifier."""
+        await self._request(
+            "POST",
+            f"/bookings/{booking_id}/cancel",
+            json={},
+        )
+        # Keep cache consistent with changed availability
+        self._availability_cache.clear()
+        logger.debug("Cleared availability cache after booking cancellation")
+
     async def _request(
         self,
         method: str,

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -23,8 +23,8 @@ from app.handlers.booking import (
     cancel,
     change_timezone,
     confirm_booking,
-    create_booking_handler,
-    create_cancel_booking_handlers,
+    create_booking_conversation_handler,
+    create_cancel_booking_flow_handlers,
     email_decision,
     enter_email,
     enter_name,
@@ -1012,8 +1012,8 @@ class TestCancelBookingCallbacks:
 
 
 class TestCancelBookingHandlerFactory:
-    def test_create_cancel_booking_handlers_returns_four_handlers(self):
-        handlers = create_cancel_booking_handlers()
+    def test_create_cancel_booking_flow_handlers_returns_four_handlers(self):
+        handlers = create_cancel_booking_flow_handlers()
         assert len(handlers) == 4
 
     def test_build_cancel_booking_keyboard(self):
@@ -1031,12 +1031,12 @@ class TestCreateBookingHandler:
     def test_sets_conversation_timeout_from_config(self):
         with patch("app.handlers.booking.settings") as mock_settings:
             mock_settings.booking_conversation_timeout_seconds = 900
-            handler = create_booking_handler()
+            handler = create_booking_conversation_handler()
 
         assert handler.conversation_timeout == timedelta(seconds=900)
 
     def test_registers_timeout_state_handler(self):
-        handler = create_booking_handler()
+        handler = create_booking_conversation_handler()
 
         assert ConversationHandler.TIMEOUT in handler.states
         timeout_handlers = handler.states[ConversationHandler.TIMEOUT]

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1,6 +1,6 @@
 """Tests for the booking conversation handler."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,12 +13,18 @@ from app.handlers.booking import (
     _format_duration,
     booking_timeout,
     book_command,
+    cancel_booking_back,
+    cancel_booking_command,
+    cancel_booking_confirm,
+    cancel_booking_select,
     build_availability_keyboard,
+    build_cancel_booking_keyboard,
     build_timezone_keyboard,
     cancel,
     change_timezone,
     confirm_booking,
     create_booking_handler,
+    create_cancel_booking_handlers,
     email_decision,
     enter_email,
     enter_name,
@@ -86,6 +92,7 @@ def mock_calcom_client():
     client = AsyncMock()
     client.get_availability = AsyncMock()
     client.create_booking = AsyncMock()
+    client.cancel_booking = AsyncMock()
     return client
 
 
@@ -93,7 +100,11 @@ def mock_calcom_client():
 def mock_context(mock_calcom_client):
     context = MagicMock()
     context.bot = AsyncMock()
-    context.bot_data = {"calcom_client": mock_calcom_client}
+    context.bot_data = {
+        "calcom_client": mock_calcom_client,
+        "booking_service": MagicMock(),
+        "whitelist_service": MagicMock(),
+    }
     context.user_data = {}
     return context
 
@@ -654,6 +665,27 @@ class TestConfirmBooking:
         assert "подтверждена" in final_message.lower() or "готово" in final_message.lower()
 
     @pytest.mark.asyncio
+    async def test_persists_booking_for_cancel_flow(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        booking_response,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = user_data_ready
+        mock_calcom_client.create_booking.return_value = booking_response
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.calcom_event_type_id = 42
+            await confirm_booking(mock_update_with_query, mock_context)
+
+        mock_context.bot_data["booking_service"].save_booking.assert_called_once_with(
+            12345, booking_response
+        )
+
+    @pytest.mark.asyncio
     async def test_uses_placeholder_email_when_none(
         self,
         mock_update_with_query,
@@ -872,6 +904,127 @@ class TestBookingTimeout:
             await booking_timeout(mock_update_with_query, mock_context)
 
         assert mock_context.user_data == {}
+
+
+class TestCancelBookingCommand:
+    @pytest.mark.asyncio
+    async def test_requires_whitelist(self, mock_update, mock_context):
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = False
+
+        await cancel_booking_command(mock_update, mock_context)
+
+        response = mock_update.message.reply_text.call_args[0][0]
+        assert "только одобренным" in response
+
+    @pytest.mark.asyncio
+    async def test_shows_no_bookings_message(self, mock_update, mock_context):
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = True
+        mock_context.bot_data["booking_service"].list_upcoming_bookings.return_value = []
+
+        await cancel_booking_command(mock_update, mock_context)
+
+        response = mock_update.message.reply_text.call_args[0][0]
+        assert "нет предстоящих записей" in response.lower()
+
+    @pytest.mark.asyncio
+    async def test_shows_keyboard_for_upcoming_bookings(self, mock_update, mock_context):
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = True
+        booking = MagicMock()
+        booking.id = 7
+        booking.title = "Step session"
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+        mock_context.bot_data["booking_service"].list_upcoming_bookings.return_value = [booking]
+
+        await cancel_booking_command(mock_update, mock_context)
+
+        kwargs = mock_update.message.reply_text.call_args[1]
+        assert "reply_markup" in kwargs
+
+
+class TestCancelBookingCallbacks:
+    @pytest.mark.asyncio
+    async def test_select_shows_confirmation(self, mock_update_with_query, mock_context):
+        mock_update_with_query.callback_query.data = "cancel_booking_select:3"
+        booking = MagicMock()
+        booking.id = 3
+        booking.status = "active"
+        booking.title = "Step session"
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+        booking.end = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
+        mock_context.bot_data["booking_service"].get_booking_for_user.return_value = booking
+
+        await cancel_booking_select(mock_update_with_query, mock_context)
+
+        mock_update_with_query.callback_query.edit_message_text.assert_called_once()
+        call_text = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
+        assert "Вы уверены" in call_text
+
+    @pytest.mark.asyncio
+    async def test_confirm_cancels_booking(self, mock_update_with_query, mock_context):
+        mock_update_with_query.callback_query.data = "cancel_booking_confirm:3"
+        booking = MagicMock()
+        booking.id = 3
+        booking.status = "active"
+        booking.title = "Step session"
+        booking.calcom_booking_id = 99
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+        booking.end = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
+        mock_context.bot_data["booking_service"].get_booking_for_user.return_value = booking
+
+        await cancel_booking_confirm(mock_update_with_query, mock_context)
+
+        mock_context.bot_data["calcom_client"].cancel_booking.assert_awaited_once_with(99)
+        mock_context.bot_data["booking_service"].mark_cancelled.assert_called_once_with(3, 12345)
+
+    @pytest.mark.asyncio
+    async def test_confirm_handles_calcom_error(self, mock_update_with_query, mock_context):
+        mock_update_with_query.callback_query.data = "cancel_booking_confirm:3"
+        booking = MagicMock()
+        booking.id = 3
+        booking.status = "active"
+        booking.calcom_booking_id = 99
+        booking.title = "Step session"
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+        booking.end = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
+        mock_context.bot_data["booking_service"].get_booking_for_user.return_value = booking
+        mock_context.bot_data["calcom_client"].cancel_booking.side_effect = CalComAPIError(
+            500, "server"
+        )
+
+        await cancel_booking_confirm(mock_update_with_query, mock_context)
+
+        text = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
+        assert "Не удалось отменить" in text
+
+    @pytest.mark.asyncio
+    async def test_back_shows_booking_list(self, mock_update_with_query, mock_context):
+        mock_update_with_query.callback_query.data = "cancel_booking_back"
+        booking = MagicMock()
+        booking.id = 7
+        booking.title = "Step session"
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+        mock_context.bot_data["booking_service"].list_upcoming_bookings.return_value = [booking]
+
+        await cancel_booking_back(mock_update_with_query, mock_context)
+
+        text = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
+        assert "Выберите запись" in text
+
+
+class TestCancelBookingHandlerFactory:
+    def test_create_cancel_booking_handlers_returns_four_handlers(self):
+        handlers = create_cancel_booking_handlers()
+        assert len(handlers) == 4
+
+    def test_build_cancel_booking_keyboard(self):
+        booking = MagicMock()
+        booking.id = 12
+        booking.title = "Step session"
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+
+        keyboard = build_cancel_booking_keyboard([booking])
+        first_button = keyboard.inline_keyboard[0][0]
+        assert first_button.callback_data == "cancel_booking_select:12"
 
 
 class TestCreateBookingHandler:

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -11,16 +11,16 @@ from app.constants import RUSSIAN_TIMEZONES
 from app.handlers.booking import (
     BookingState,
     _format_duration,
-    booking_timeout,
     book_command,
-    cancel_booking_back,
-    cancel_booking_command,
-    cancel_booking_confirm,
-    cancel_booking_select,
+    booking_timeout,
     build_availability_keyboard,
     build_cancel_booking_keyboard,
     build_timezone_keyboard,
     cancel,
+    cancel_booking_back,
+    cancel_booking_command,
+    cancel_booking_confirm,
+    cancel_booking_select,
     change_timezone,
     confirm_booking,
     create_booking_conversation_handler,
@@ -960,6 +960,17 @@ class TestCancelBookingCallbacks:
         assert "Вы уверены" in call_text
 
     @pytest.mark.asyncio
+    async def test_select_denies_non_whitelisted_user(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "cancel_booking_select:3"
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = False
+
+        await cancel_booking_select(mock_update_with_query, mock_context)
+
+        mock_context.bot_data["booking_service"].get_booking_for_user.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_confirm_cancels_booking(self, mock_update_with_query, mock_context):
         mock_update_with_query.callback_query.data = "cancel_booking_confirm:3"
         booking = MagicMock()
@@ -974,6 +985,27 @@ class TestCancelBookingCallbacks:
         await cancel_booking_confirm(mock_update_with_query, mock_context)
 
         mock_context.bot_data["calcom_client"].cancel_booking.assert_awaited_once_with(99)
+        mock_context.bot_data["booking_service"].mark_cancelled.assert_called_once_with(3, 12345)
+
+    @pytest.mark.asyncio
+    async def test_confirm_marks_local_booking_cancelled_on_terminal_calcom_error(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "cancel_booking_confirm:3"
+        booking = MagicMock()
+        booking.id = 3
+        booking.status = "active"
+        booking.calcom_booking_id = 99
+        booking.title = "Step session"
+        booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
+        booking.end = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
+        mock_context.bot_data["booking_service"].get_booking_for_user.return_value = booking
+        mock_context.bot_data["calcom_client"].cancel_booking.side_effect = CalComAPIError(
+            404, "not found"
+        )
+
+        await cancel_booking_confirm(mock_update_with_query, mock_context)
+
         mock_context.bot_data["booking_service"].mark_cancelled.assert_called_once_with(3, 12345)
 
     @pytest.mark.asyncio
@@ -997,6 +1029,30 @@ class TestCancelBookingCallbacks:
         assert "Не удалось отменить" in text
 
     @pytest.mark.asyncio
+    async def test_confirm_denies_non_whitelisted_user_and_skips_calcom(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "cancel_booking_confirm:3"
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = False
+
+        await cancel_booking_confirm(mock_update_with_query, mock_context)
+
+        mock_context.bot_data["booking_service"].get_booking_for_user.assert_not_called()
+        mock_context.bot_data["calcom_client"].cancel_booking.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_confirm_denies_when_whitelist_service_missing(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "cancel_booking_confirm:3"
+        del mock_context.bot_data["whitelist_service"]
+
+        await cancel_booking_confirm(mock_update_with_query, mock_context)
+
+        mock_context.bot_data["booking_service"].get_booking_for_user.assert_not_called()
+        mock_context.bot_data["calcom_client"].cancel_booking.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_back_shows_booking_list(self, mock_update_with_query, mock_context):
         mock_update_with_query.callback_query.data = "cancel_booking_back"
         booking = MagicMock()
@@ -1009,6 +1065,15 @@ class TestCancelBookingCallbacks:
 
         text = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
         assert "Выберите запись" in text
+
+    @pytest.mark.asyncio
+    async def test_back_denies_non_whitelisted_user(self, mock_update_with_query, mock_context):
+        mock_update_with_query.callback_query.data = "cancel_booking_back"
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = False
+
+        await cancel_booking_back(mock_update_with_query, mock_context)
+
+        mock_context.bot_data["booking_service"].list_upcoming_bookings.assert_not_called()
 
 
 class TestCancelBookingHandlerFactory:

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -1,0 +1,68 @@
+"""Tests for persisted booking storage service."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.database import Database
+from app.database.migrations import initialize_schema
+from app.services.booking_service import BookingService
+from app.services.calcom_client import BookingResponse
+
+
+def _make_booking_response(
+    booking_id: int,
+    start: datetime,
+    end: datetime,
+) -> BookingResponse:
+    return BookingResponse(
+        id=booking_id,
+        uid=f"uid-{booking_id}",
+        title=f"Meeting {booking_id}",
+        start=start.isoformat().replace("+00:00", "Z"),
+        end=end.isoformat().replace("+00:00", "Z"),
+        status="accepted",
+    )
+
+
+def test_save_and_list_upcoming_bookings(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = BookingService(db)
+
+    now = datetime.now(timezone.utc)
+    upcoming = _make_booking_response(1001, now + timedelta(hours=1), now + timedelta(hours=2))
+    past = _make_booking_response(1002, now - timedelta(hours=3), now - timedelta(hours=2))
+
+    service.save_booking(telegram_id=12345, booking=upcoming)
+    service.save_booking(telegram_id=12345, booking=past)
+
+    results = service.list_upcoming_bookings(12345)
+
+    assert len(results) == 1
+    assert results[0].calcom_booking_id == 1001
+
+
+def test_get_booking_for_user_enforces_ownership(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = BookingService(db)
+
+    now = datetime.now(timezone.utc)
+    booking = _make_booking_response(2001, now + timedelta(hours=1), now + timedelta(hours=2))
+    row_id = service.save_booking(telegram_id=111, booking=booking)
+
+    assert service.get_booking_for_user(row_id, telegram_id=111) is not None
+    assert service.get_booking_for_user(row_id, telegram_id=222) is None
+
+
+def test_mark_cancelled_hides_booking_from_upcoming(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = BookingService(db)
+
+    now = datetime.now(timezone.utc)
+    booking = _make_booking_response(3001, now + timedelta(hours=1), now + timedelta(hours=2))
+    row_id = service.save_booking(telegram_id=12345, booking=booking)
+
+    assert service.mark_cancelled(row_id, telegram_id=12345) is True
+    assert service.mark_cancelled(row_id, telegram_id=12345) is False
+    assert service.list_upcoming_bookings(12345) == []

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,7 @@
 """Tests for database functionality."""
 
 from app.database import Database
-from app.database.migrations import initialize_schema
+from app.database.migrations import initialize_schema, run_migrations
 
 
 def test_database_creates_file(temp_db_path):
@@ -80,3 +80,54 @@ def test_access_request_status_constraint(temp_db_path):
         assert False, "Should have raised an error for invalid status"
     except sqlite3.IntegrityError:
         pass  # Expected
+
+
+def test_migrates_bookings_start_end_columns(temp_db_path):
+    """Legacy bookings schema is migrated to start_at/end_at."""
+    db = Database(temp_db_path)
+
+    db.execute_write(
+        """
+        CREATE TABLE IF NOT EXISTS bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            telegram_id INTEGER NOT NULL,
+            calcom_booking_id INTEGER NOT NULL,
+            calcom_booking_uid TEXT NOT NULL,
+            title TEXT NOT NULL,
+            start TEXT NOT NULL,
+            "end" TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            created_at TEXT NOT NULL,
+            cancelled_at TEXT,
+            UNIQUE(telegram_id, calcom_booking_id)
+        )
+        """
+    )
+    db.execute_write(
+        """
+        INSERT INTO bookings (
+            telegram_id, calcom_booking_id, calcom_booking_uid, title, start, "end", status, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            123,
+            456,
+            "uid-456",
+            "Meeting",
+            "2026-01-01T10:00:00Z",
+            "2026-01-01T11:00:00Z",
+            "active",
+            "2026-01-01T00:00:00Z",
+        ),
+    )
+
+    run_migrations(db)
+
+    columns = {row["name"] for row in db.execute("PRAGMA table_info(bookings)")}
+    assert "start_at" in columns
+    assert "end_at" in columns
+
+    row = db.execute_one("SELECT start_at, end_at FROM bookings WHERE telegram_id = ?", (123,))
+    assert row["start_at"] == "2026-01-01T10:00:00Z"
+    assert row["end_at"] == "2026-01-01T11:00:00Z"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,6 +25,7 @@ def test_schema_initialization(temp_db_path):
     assert "whitelist" in table_names
     assert "access_requests" in table_names
     assert "user_preferences" in table_names
+    assert "bookings" in table_names
 
 
 def test_whitelist_insert_and_query(temp_db_path):

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -47,7 +47,7 @@ class TestHelpCommand:
     async def test_whitelisted_user_sees_available_commands(
         self, mock_update, mock_context, whitelist_service
     ):
-        """Whitelisted user sees /book and /help commands."""
+        """Whitelisted user sees booking command set."""
         whitelist_service.add_to_whitelist(
             telegram_id=12345,
             display_name="Test",
@@ -59,6 +59,7 @@ class TestHelpCommand:
 
         response = mock_update.message.reply_text.call_args[0][0]
         assert "/book" in response
+        assert "/cancel_booking" in response
         assert "/help" in response
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add persisted `bookings` storage and `BookingService` to track Cal.com booking IDs per Telegram user
- store successful bookings after `/book` confirmation so they can be cancelled later
- add `/cancel_booking` flow with inline booking selection, confirmation step, and back navigation
- call Cal.com cancellation endpoint and mark bookings cancelled locally on success
- gate `/cancel_booking` to whitelisted users and expose it in `/help`

Closes #17

## Verification
- `uv run pytest tests/test_booking_service.py tests/test_booking.py tests/test_calcom_client.py tests/test_help.py tests/test_database.py -q` -> `111 passed`
- `uv run pytest -q` -> `156 passed`