### PR TITLE
Add GitHub Actions Fly deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2
 
       - name: Deploy
         run: flyctl deploy --remote-only


### PR DESCRIPTION
## Summary
- add deploy workflow triggered on push to main
- add manual workflow_dispatch trigger for ad-hoc redeploys
- use repository secret FLY_API_TOKEN for flyctl auth

## Verification
- workflow YAML added at .github/workflows/deploy.yml
- local tests not run (CI workflow config change only)