### PR TITLE
Keep one Fly machine always running for polling bot

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,9 +15,9 @@ app = "/app/.venv/bin/python -m app.main"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[mounts]]


### PR DESCRIPTION
## Summary
- disable Fly machine autostop for the app process
- keep one machine running continuously to support Telegram long polling availability

## Verification
- `uv run pytest tests/test_main.py -q`
- Result: `3 passed, 1 warning`