### PR TITLE
fix: block booking before approval

### DIFF
--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -26,6 +26,7 @@ from app.services.calcom_client import (
     CalComClient,
 )
 from app.services.duration_limit import DurationLimitService
+from app.services.whitelist import WhitelistService
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,27 @@ async def _safe_edit_message_text(query, text: str, reply_markup=None) -> None:
         raise
 
 
+async def _deny_booking_access(update: Update) -> None:
+    """Tell unapproved users they need approval before booking."""
+    text = (
+        "Доступ к записи доступен только одобренным пользователям.\n"
+        "Используйте /start, чтобы запросить доступ."
+    )
+    if update.message:
+        await update.message.reply_text(text)
+    elif update.callback_query:
+        await _safe_edit_message_text(update.callback_query, text)
+
+
+def _is_whitelisted(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
+    """Return access status. Missing whitelist service defaults to allow for test safety."""
+    whitelist_service: WhitelistService | None = context.bot_data.get("whitelist_service")
+    if whitelist_service is None:
+        return True
+    user_id = update.effective_user.id
+    return whitelist_service.is_whitelisted(user_id)
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -94,6 +116,10 @@ async def _safe_edit_message_text(query, text: str, reply_markup=None) -> None:
 
 async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Start the booking conversation with timezone selection."""
+    if not _is_whitelisted(update, context):
+        await _deny_booking_access(update)
+        return ConversationHandler.END
+
     keyboard = build_timezone_keyboard()
     await update.message.reply_text(
         "Выберите ваш часовой пояс:",
@@ -410,6 +436,10 @@ def _confirmation_keyboard() -> InlineKeyboardMarkup:
 
 async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Create the booking via Cal.com API."""
+    if not _is_whitelisted(update, context):
+        await _deny_booking_access(update)
+        return ConversationHandler.END
+
     query = update.callback_query
     await query.answer()
 

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -101,10 +101,11 @@ async def _deny_booking_access(update: Update) -> None:
 
 
 def _is_whitelisted(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
-    """Return access status. Missing whitelist service defaults to allow for test safety."""
+    """Return access status. Missing whitelist service is treated as denied."""
     whitelist_service: WhitelistService | None = context.bot_data.get("whitelist_service")
     if whitelist_service is None:
-        return True
+        logger.warning("whitelist_service missing in bot_data; denying booking access")
+        return False
     user_id = update.effective_user.id
     return whitelist_service.is_whitelisted(user_id)
 

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -617,6 +617,12 @@ class TestEnterEmail:
 
 
 class TestConfirmBooking:
+    @pytest.fixture(autouse=True)
+    def allow_whitelisted_user(self, mock_context):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = True
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+
     @pytest.fixture
     def user_data_ready(self):
         return {
@@ -638,6 +644,42 @@ class TestConfirmBooking:
             end="2026-01-06T08:00:00Z",
             status="accepted",
         )
+
+    @pytest.mark.asyncio
+    async def test_blocks_non_whitelisted_user_and_does_not_create_booking(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+    ):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = False
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+        mock_context.user_data = user_data_ready
+
+        result = await confirm_booking(mock_update_with_query, mock_context)
+
+        assert result == ConversationHandler.END
+        mock_calcom_client.create_booking.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_blocks_booking_when_whitelist_service_missing(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        caplog,
+    ):
+        mock_context.bot_data.pop("whitelist_service", None)
+        mock_context.user_data = user_data_ready
+
+        result = await confirm_booking(mock_update_with_query, mock_context)
+
+        assert result == ConversationHandler.END
+        mock_calcom_client.create_booking.assert_not_called()
+        assert "whitelist_service missing in bot_data" in caplog.text
 
     @pytest.mark.asyncio
     async def test_creates_booking_with_correct_data(

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -300,11 +300,19 @@ class TestBookCommand:
 
     @pytest.mark.asyncio
     async def test_returns_selecting_timezone(self, mock_update, mock_context):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = True
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+
         result = await book_command(mock_update, mock_context)
         assert result == BookingState.SELECTING_TIMEZONE
 
     @pytest.mark.asyncio
     async def test_sends_timezone_keyboard(self, mock_update, mock_context):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = True
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+
         await book_command(mock_update, mock_context)
         mock_update.message.reply_text.assert_called_once()
         call_kwargs = mock_update.message.reply_text.call_args[1]

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -276,6 +276,29 @@ class TestBuildAvailabilityKeyboard:
 
 class TestBookCommand:
     @pytest.mark.asyncio
+    async def test_blocks_non_whitelisted_user(self, mock_update, mock_context):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = False
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+
+        result = await book_command(mock_update, mock_context)
+
+        assert result == ConversationHandler.END
+        mock_update.message.reply_text.assert_called_once()
+        assert mock_update.message.reply_text.call_args[1].get("reply_markup") is None
+
+    @pytest.mark.asyncio
+    async def test_allows_whitelisted_user(self, mock_update, mock_context):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = True
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+
+        result = await book_command(mock_update, mock_context)
+
+        assert result == BookingState.SELECTING_TIMEZONE
+        assert "reply_markup" in mock_update.message.reply_text.call_args[1]
+
+    @pytest.mark.asyncio
     async def test_returns_selecting_timezone(self, mock_update, mock_context):
         result = await book_command(mock_update, mock_context)
         assert result == BookingState.SELECTING_TIMEZONE


### PR DESCRIPTION
Fixes #50.

- Enforce whitelist check at /book entry point.
- Enforce whitelist check again at confirm_booking to prevent bypass.
- Adds tests for non-whitelisted blocked + whitelisted allowed.

Notes:
- Access denial ends the conversation handler immediately.
