### PR TITLE
Make access approval atomic

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -2,6 +2,7 @@
 
 import logging
 from functools import wraps
+from typing import Awaitable, Callable, cast
 
 from telegram import Update
 from telegram.ext import ContextTypes
@@ -11,20 +12,22 @@ from app.services.whitelist import WhitelistService
 
 logger = logging.getLogger(__name__)
 
+AdminHandler = Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[None]]
 
-def admin_only(func):
+
+def admin_only(func: AdminHandler) -> AdminHandler:
     """Decorator to restrict handler to admin user only."""
 
     @wraps(func)
-    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         user_id = update.effective_user.id
         if user_id != settings.admin_telegram_id:
             logger.warning(f"Unauthorized admin access attempt by user {user_id}")
             await update.message.reply_text("You are not authorized to use this command.")
             return
-        return await func(update, context)
+        await func(update, context)
 
-    return wrapper
+    return cast(AdminHandler, wrapper)
 
 
 @admin_only

--- a/app/services/whitelist.py
+++ b/app/services/whitelist.py
@@ -125,23 +125,39 @@ class WhitelistService:
 
         Returns True if request was found and approved, False otherwise.
         """
-        request = self.get_access_request(telegram_id)
-        if request is None or request.status != "pending":
-            return False
+        now = datetime.now(timezone.utc).isoformat()
+        with self.db.get_connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            request = conn.execute(
+                "SELECT * FROM access_requests WHERE telegram_id = ?",
+                (telegram_id,),
+            ).fetchone()
+            if request is None or request["status"] != "pending":
+                return False
 
-        # Add to whitelist
-        self.add_to_whitelist(
-            telegram_id=request.telegram_id,
-            display_name=request.display_name,
-            username=request.username,
-            approved_by=approved_by,
-        )
+            conn.execute(
+                """
+                INSERT INTO whitelist (telegram_id, display_name, username, approved_at, approved_by)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(telegram_id) DO UPDATE SET
+                    display_name = excluded.display_name,
+                    username = excluded.username,
+                    approved_at = excluded.approved_at,
+                    approved_by = excluded.approved_by
+                """,
+                (
+                    request["telegram_id"],
+                    request["display_name"],
+                    request["username"],
+                    now,
+                    approved_by,
+                ),
+            )
 
-        # Update request status
-        self.db.execute_write(
-            "UPDATE access_requests SET status = 'approved' WHERE telegram_id = ?",
-            (telegram_id,),
-        )
+            conn.execute(
+                "UPDATE access_requests SET status = 'approved' WHERE telegram_id = ?",
+                (telegram_id,),
+            )
 
         return True
 

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -207,6 +207,33 @@ class TestApproveRequest:
         assert request is not None
         assert request.status == "approved"
 
+    def test_rolls_back_whitelist_when_status_update_fails(self, whitelist_service):
+        """Whitelist insert and request approval are one atomic operation."""
+        whitelist_service.create_access_request(
+            telegram_id=123,
+            display_name="Test User",
+            username="testuser",
+        )
+        whitelist_service.db.execute_write(
+            """
+            CREATE TRIGGER fail_approved_status_update
+            BEFORE UPDATE OF status ON access_requests
+            WHEN new.status = 'approved'
+            BEGIN
+                SELECT RAISE(ABORT, 'status update failed');
+            END
+            """
+        )
+
+        with pytest.raises(Exception, match="status update failed"):
+            whitelist_service.approve_request(123, approved_by=789)
+
+        assert whitelist_service.is_whitelisted(123) is False
+
+        request = whitelist_service.get_access_request(123)
+        assert request is not None
+        assert request.status == "pending"
+
 
 class TestRejectRequest:
     """Tests for reject_request method."""


### PR DESCRIPTION
## Summary

- Made `WhitelistService.approve_request` perform the whitelist upsert and access request status update in a single SQLite transaction.
- Added a regression that forces the approval status update to fail and verifies the whitelist insert rolls back.
- Added precise type hints to the `admin_only` decorator without changing handler behavior.

## Linked Issue

- Closes #12

## Verification Evidence

- Commands run:
  - `uv run pytest tests/test_whitelist.py::TestApproveRequest::test_rolls_back_whitelist_when_status_update_fails -q`
  - `uv run pytest tests/test_whitelist.py -q`
  - `uv run pytest tests/test_admin.py -q`
  - `uv run pytest tests/ -v`
  - `uv run ruff check .`
  - `uv sync --frozen`
  - `docker build -t telecalbot:ci .`
  - `docker run --rm -e TELEGRAM_BOT_TOKEN=123:ABC -e CALCOM_API_KEY=dummy -e ADMIN_TELEGRAM_ID=1 -e DATABASE_PATH=/tmp/telecalbot.db telecalbot:ci /app/.venv/bin/python -c "import app.main; print('import-ok')"`
  - `docker run --rm -e TELEGRAM_BOT_TOKEN=123:ABC -e CALCOM_API_KEY=dummy -e ADMIN_TELEGRAM_ID=1 -e DATABASE_PATH=/tmp/telecalbot.db telecalbot:ci /app/.venv/bin/python -c "from app.database import db, run_migrations; run_migrations(db); print('migrations-ok')"`
- Results with concrete counts/status:
  - Regression test failed before the fix, then passed after the fix.
  - `tests/test_whitelist.py`: 23 passed.
  - `tests/test_admin.py`: 11 passed.
  - Full suite: 209 passed, 3 warnings.
  - Ruff: all checks passed.
  - `uv sync --frozen`: audited 24 packages.
  - Docker build succeeded.
  - Docker import smoke printed `import-ok`.
  - Docker migration smoke printed `migrations-ok`.

## Scope Check

- [x] Change is focused to one scoped task.
- [x] No unrelated files are included.
- [x] Required docs/config updates are included. No docs/config changes were required.

## Risk and Rollback

- Risk: low; the approval path now uses a single explicit transaction and existing approval/rejection coverage remains green.
- Rollback: revert commit `0171e2d` if needed.