### PR TITLE
[codex] harden Cal.com client contract

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,10 +10,6 @@ TELEGRAM_BOT_TOKEN=
 # Get your API key from Cal.com account settings
 CALCOM_API_KEY=
 
-# Fallback Cal.com API version for endpoints without a client-pinned version.
-# The client pins current versions for slots and bookings directly.
-CAL_API_VERSION=2024-06-14
-
 # Dedicated deliverable mailbox used when a user skips their personal email (optional)
 # Required for private bookings; use a privacy-specific operational inbox
 CALCOM_PRIVACY_EMAIL=

--- a/.env.sample
+++ b/.env.sample
@@ -10,9 +10,9 @@ TELEGRAM_BOT_TOKEN=
 # Get your API key from Cal.com account settings
 CALCOM_API_KEY=
 
-# Cal.com API version header
-# Check Cal.com API docs for the latest version
-CAL_API_VERSION=2024-08-13
+# Fallback Cal.com API version for endpoints without a client-pinned version.
+# The client pins current versions for slots and bookings directly.
+CAL_API_VERSION=2024-06-14
 
 # Dedicated deliverable mailbox used when a user skips their personal email (optional)
 # Required for private bookings; use a privacy-specific operational inbox

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
 
     # Cal.com API Configuration (Required)
     calcom_api_key: str
-    cal_api_version: str = "2024-08-13"
+    cal_api_version: str = "2024-06-14"
     calcom_privacy_email: str | None = None
 
     # Admin Configuration (Required)

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,6 @@ class Settings(BaseSettings):
 
     # Cal.com API Configuration (Required)
     calcom_api_key: str
-    cal_api_version: str = "2024-06-14"
     calcom_privacy_email: str | None = None
 
     # Admin Configuration (Required)

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -1021,7 +1021,7 @@ async def cancel_booking_confirm(update: Update, context: ContextTypes.DEFAULT_T
         return
 
     try:
-        await calcom_client.cancel_booking(booking.calcom_booking_id)
+        await calcom_client.cancel_booking(booking.calcom_booking_uid)
     except CalComAPIError as error:
         if error.status_code in CANCEL_BOOKING_TERMINAL_STATUS_CODES:
             booking_service.mark_cancelled(booking_row_id, user_id)

--- a/app/main.py
+++ b/app/main.py
@@ -79,10 +79,7 @@ def main() -> None:
     application.bot_data["whitelist_service"] = WhitelistService(db)
     application.bot_data["duration_limit_service"] = DurationLimitService(db)
     application.bot_data["booking_service"] = BookingService(db)
-    application.bot_data["calcom_client"] = CalComClient(
-        api_key=settings.calcom_api_key,
-        api_version=settings.cal_api_version,
-    )
+    application.bot_data["calcom_client"] = CalComClient(api_key=settings.calcom_api_key)
 
     # Register handlers
     application.add_handler(CommandHandler("start", start_command))

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import math
 import re
 import time
 from datetime import date
@@ -100,33 +101,28 @@ class CalComClient:
     """Async Cal.com API client with caching."""
 
     BASE_URL = "https://api.cal.com/v2"
-    DEFAULT_API_VERSION = "2024-06-14"
     SLOTS_API_VERSION = "2024-09-04"
     BOOKINGS_API_VERSION = "2026-02-25"
     MAX_RETRIES = 3
     INITIAL_RETRY_DELAY_SECONDS = 0.5
+    MAX_RETRY_DELAY_SECONDS = 10.0
     RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
 
     def __init__(
         self,
         api_key: str,
-        api_version: str,
         cache_ttl: int = 300,
     ):
         """Initialize the Cal.com client.
 
         Args:
             api_key: Cal.com API key.
-            api_version: Fallback Cal.com API version for endpoints without
-                an explicit endpoint-specific version.
             cache_ttl: Cache TTL in seconds (default 300 = 5 minutes).
         """
-        self.api_version = api_version or self.DEFAULT_API_VERSION
         self._client = httpx.AsyncClient(
             base_url=self.BASE_URL,
             headers={
                 "Authorization": f"Bearer {api_key}",
-                "cal-api-version": self.api_version,
                 "Content-Type": "application/json",
             },
             timeout=30.0,
@@ -242,7 +238,8 @@ class CalComClient:
         self,
         method: str,
         path: str,
-        api_version: str | None = None,
+        *,
+        api_version: str,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Make HTTP request to Cal.com API.
@@ -261,9 +258,9 @@ class CalComClient:
         """
         delay_seconds = self.INITIAL_RETRY_DELAY_SECONDS
         last_error: CalComAPIError | None = None
+        request_kwargs = self._with_api_version_header(kwargs, api_version)
 
         for attempt in range(1, self.MAX_RETRIES + 2):
-            request_kwargs = self._with_api_version_header(kwargs, api_version)
             try:
                 response = await self._client.request(method, path, **request_kwargs)
                 response.raise_for_status()
@@ -313,18 +310,18 @@ class CalComClient:
     def _with_api_version_header(
         self,
         kwargs: dict[str, Any],
-        api_version: str | None,
+        api_version: str,
     ) -> dict[str, Any]:
         """Return request kwargs with the correct Cal.com API version header."""
         request_kwargs = dict(kwargs)
         headers = dict(request_kwargs.pop("headers", {}))
-        headers.setdefault("cal-api-version", api_version or self.api_version)
+        headers["cal-api-version"] = api_version
         request_kwargs["headers"] = headers
         return request_kwargs
 
     @staticmethod
     def _retry_delay_seconds(response: httpx.Response, fallback_seconds: float) -> float:
-        """Use Retry-After for rate limits when Cal.com provides it."""
+        """Use bounded numeric Retry-After values, falling back for HTTP dates."""
         if response.status_code != 429:
             return fallback_seconds
 
@@ -337,7 +334,10 @@ class CalComClient:
         except ValueError:
             return fallback_seconds
 
-        return max(seconds, 0.0)
+        if not math.isfinite(seconds):
+            return fallback_seconds
+
+        return min(max(seconds, 0.0), CalComClient.MAX_RETRY_DELAY_SECONDS)
 
     @staticmethod
     def _parse_availability(data: dict[str, Any]) -> AvailabilityResponse:
@@ -345,15 +345,24 @@ class CalComClient:
         raw_slots = data.get("slots", data)
         normalized_slots: dict[str, list[dict[str, str]]] = {}
 
+        if not isinstance(raw_slots, dict):
+            return AvailabilityResponse(slots={})
+
         for day, slots in raw_slots.items():
+            if not isinstance(day, str) or not isinstance(slots, list):
+                continue
+
             normalized_slots[day] = []
             for slot in slots:
                 if isinstance(slot, str):
                     normalized_slots[day].append({"time": slot})
                     continue
 
+                if not isinstance(slot, dict):
+                    continue
+
                 slot_time = slot.get("time") or slot.get("start")
-                if slot_time is not None:
+                if isinstance(slot_time, str):
                     normalized_slots[day].append({"time": slot_time})
 
         return AvailabilityResponse.model_validate({"slots": normalized_slots})

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -8,7 +8,7 @@ from datetime import date
 from typing import Any
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ class BookingRequest(BaseModel):
     start: str  # ISO 8601 UTC datetime
     lengthInMinutes: int | None = None
     attendee: Attendee
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class BookingResponse(BaseModel):
@@ -100,6 +100,9 @@ class CalComClient:
     """Async Cal.com API client with caching."""
 
     BASE_URL = "https://api.cal.com/v2"
+    DEFAULT_API_VERSION = "2024-06-14"
+    SLOTS_API_VERSION = "2024-09-04"
+    BOOKINGS_API_VERSION = "2026-02-25"
     MAX_RETRIES = 3
     INITIAL_RETRY_DELAY_SECONDS = 0.5
     RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
@@ -114,14 +117,16 @@ class CalComClient:
 
         Args:
             api_key: Cal.com API key.
-            api_version: Cal.com API version (e.g., "2024-06-14").
+            api_version: Fallback Cal.com API version for endpoints without
+                an explicit endpoint-specific version.
             cache_ttl: Cache TTL in seconds (default 300 = 5 minutes).
         """
+        self.api_version = api_version or self.DEFAULT_API_VERSION
         self._client = httpx.AsyncClient(
             base_url=self.BASE_URL,
             headers={
                 "Authorization": f"Bearer {api_key}",
-                "cal-api-version": api_version,
+                "cal-api-version": self.api_version,
                 "Content-Type": "application/json",
             },
             timeout=30.0,
@@ -178,8 +183,8 @@ class CalComClient:
         # Fetch from API
         params = {
             "eventTypeId": event_type_id,
-            "startTime": f"{start_date}T00:00:00Z",
-            "endTime": f"{end_date}T23:59:59Z",
+            "start": start_date.isoformat(),
+            "end": end_date.isoformat(),
             "timeZone": timezone,
         }
         if duration_minutes is not None:
@@ -187,11 +192,12 @@ class CalComClient:
 
         response = await self._request(
             "GET",
-            "/slots/available",
+            "/slots",
+            api_version=self.SLOTS_API_VERSION,
             params=params,
         )
 
-        data = AvailabilityResponse.model_validate(response["data"])
+        data = self._parse_availability(response["data"])
         self._availability_cache[cache_key] = (time.time(), data)
         return data
 
@@ -210,6 +216,7 @@ class CalComClient:
         response = await self._request(
             "POST",
             "/bookings",
+            api_version=self.BOOKINGS_API_VERSION,
             json=request.model_dump(exclude_none=True),
         )
 
@@ -219,11 +226,12 @@ class CalComClient:
 
         return BookingResponse.model_validate(response["data"])
 
-    async def cancel_booking(self, booking_id: int | str) -> None:
-        """Cancel an existing booking by Cal.com booking identifier."""
+    async def cancel_booking(self, booking_uid: str) -> None:
+        """Cancel an existing booking by Cal.com booking UID."""
         await self._request(
             "POST",
-            f"/bookings/{booking_id}/cancel",
+            f"/bookings/{booking_uid}/cancel",
+            api_version=self.BOOKINGS_API_VERSION,
             json={},
         )
         # Keep cache consistent with changed availability
@@ -234,6 +242,7 @@ class CalComClient:
         self,
         method: str,
         path: str,
+        api_version: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Make HTTP request to Cal.com API.
@@ -241,6 +250,7 @@ class CalComClient:
         Args:
             method: HTTP method (GET, POST, etc.).
             path: API endpoint path.
+            api_version: Endpoint-specific Cal.com API version.
             **kwargs: Additional arguments for httpx request.
 
         Returns:
@@ -253,8 +263,9 @@ class CalComClient:
         last_error: CalComAPIError | None = None
 
         for attempt in range(1, self.MAX_RETRIES + 2):
+            request_kwargs = self._with_api_version_header(kwargs, api_version)
             try:
-                response = await self._client.request(method, path, **kwargs)
+                response = await self._client.request(method, path, **request_kwargs)
                 response.raise_for_status()
                 return response.json()
             except httpx.HTTPStatusError as e:
@@ -274,12 +285,14 @@ class CalComClient:
                     code=error_code,
                 )
                 should_retry = status_code in self.RETRYABLE_STATUS_CODES
+                sleep_seconds = self._retry_delay_seconds(e.response, delay_seconds)
             except httpx.RequestError as e:
                 message = str(e)
                 logger.error("Cal.com API network error: %s", message)
 
                 last_error = CalComAPIError(status_code=0, message=message)
                 should_retry = True
+                sleep_seconds = delay_seconds
 
             if not should_retry or attempt > self.MAX_RETRIES:
                 raise last_error
@@ -290,9 +303,57 @@ class CalComClient:
                 path,
                 attempt + 1,
                 self.MAX_RETRIES + 1,
-                delay_seconds,
+                sleep_seconds,
             )
-            await asyncio.sleep(delay_seconds)
+            await asyncio.sleep(sleep_seconds)
             delay_seconds *= 2
 
         raise last_error
+
+    def _with_api_version_header(
+        self,
+        kwargs: dict[str, Any],
+        api_version: str | None,
+    ) -> dict[str, Any]:
+        """Return request kwargs with the correct Cal.com API version header."""
+        request_kwargs = dict(kwargs)
+        headers = dict(request_kwargs.pop("headers", {}))
+        headers.setdefault("cal-api-version", api_version or self.api_version)
+        request_kwargs["headers"] = headers
+        return request_kwargs
+
+    @staticmethod
+    def _retry_delay_seconds(response: httpx.Response, fallback_seconds: float) -> float:
+        """Use Retry-After for rate limits when Cal.com provides it."""
+        if response.status_code != 429:
+            return fallback_seconds
+
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is None:
+            return fallback_seconds
+
+        try:
+            seconds = float(retry_after)
+        except ValueError:
+            return fallback_seconds
+
+        return max(seconds, 0.0)
+
+    @staticmethod
+    def _parse_availability(data: dict[str, Any]) -> AvailabilityResponse:
+        """Normalize supported Cal.com slot response shapes."""
+        raw_slots = data.get("slots", data)
+        normalized_slots: dict[str, list[dict[str, str]]] = {}
+
+        for day, slots in raw_slots.items():
+            normalized_slots[day] = []
+            for slot in slots:
+                if isinstance(slot, str):
+                    normalized_slots[day].append({"time": slot})
+                    continue
+
+                slot_time = slot.get("time") or slot.get("start")
+                if slot_time is not None:
+                    normalized_slots[day].append({"time": slot_time})
+
+        return AvailabilityResponse.model_validate({"slots": normalized_slots})

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -32,6 +32,19 @@ The Cal.com API v2 is fully functional and supports all requirements for the Tel
 
 **Finding**: Different endpoints require different API versions
 
+**Current verification (2026-06-14)**: Cal.com still requires endpoint-specific
+`cal-api-version` headers, but the required versions have changed since this
+research was first captured. The production client now pins:
+
+| Endpoint | Required Version |
+|----------|-----------------|
+| `GET /v2/slots` | `2024-09-04` |
+| `POST /v2/bookings` | `2026-02-25` |
+| `POST /v2/bookings/{bookingUid}/cancel` | `2026-02-25` |
+
+`CAL_API_VERSION` is treated as a fallback for endpoints without an explicit
+client-pinned version.
+
 | Endpoint | Required Version |
 |----------|-----------------|
 | `/v2/event-types` | `2024-06-14` |

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -32,7 +32,7 @@ The Cal.com API v2 is fully functional and supports all requirements for the Tel
 
 **Finding**: Different endpoints require different API versions
 
-**Current verification (2026-06-14)**: Cal.com still requires endpoint-specific
+**Current verification (2026-07-20)**: Cal.com requires endpoint-specific
 `cal-api-version` headers, but the required versions have changed since this
 research was first captured. The production client now pins:
 
@@ -42,43 +42,33 @@ research was first captured. The production client now pins:
 | `POST /v2/bookings` | `2026-02-25` |
 | `POST /v2/bookings/{bookingUid}/cancel` | `2026-02-25` |
 
-`CAL_API_VERSION` is treated as a fallback for endpoints without an explicit
-client-pinned version.
-
-| Endpoint | Required Version |
-|----------|-----------------|
-| `/v2/event-types` | `2024-06-14` |
-| `/v2/slots/available` | `2024-06-14` |
-| `/v2/bookings` | `2024-08-13` |
-
 **Implementation Decision**:
-- Use `2024-06-14` as default API version
-- Override with `2024-08-13` specifically for booking creation requests
-- Add version handling to Cal.com client wrapper
+- Pin each endpoint's required version in the Cal.com client wrapper
+- Do not expose a global `CAL_API_VERSION` setting that cannot affect pinned endpoints
+- Require every low-level client request to declare its endpoint version
 
 ---
 
 ### 3. Availability Response Format ✅
 
-**Finding**: Slots are returned as objects, not simple strings
+**Finding**: Current slots are grouped directly by date and use a `start` field
 
 **Response Structure**:
 ```json
 {
-  "slots": {
-    "2026-01-01": [
-      {"time": "2026-01-01T04:00:00.000+03:00"}
-    ],
-    "2026-01-02": [
-      {"time": "2026-01-02T05:00:00.000+03:00"},
-      {"time": "2026-01-02T06:00:00.000+03:00"}
-    ]
-  }
+  "2026-01-01": [
+    {"start": "2026-01-01T04:00:00.000+03:00"}
+  ],
+  "2026-01-02": [
+    {"start": "2026-01-02T05:00:00.000+03:00"},
+    {"start": "2026-01-02T06:00:00.000+03:00"}
+  ]
 }
 ```
 
 **Implementation Decision**:
-- Extract time from `slot.time` not from slot directly
+- Normalize current `slot.start` values into the application's `TimeSlot.time` model
+- Continue accepting the legacy `{"slots": {date: [{"time": ...}]}}` shape defensively
 - Times are already in the requested timezone (ISO format with offset)
 - Use `datetime.fromisoformat()` to parse
 
@@ -161,7 +151,7 @@ x-ratelimit-reset-default: 60
 - `start` must be ISO 8601 timestamp (can include timezone offset)
 - `attendee` object required with name, email, timeZone, language
 - `metadata` can store additional context (Telegram user ID, etc.)
-- Use API version `2024-08-13` for bookings endpoint
+- Use API version `2026-02-25` for the bookings endpoint
 
 ---
 
@@ -172,7 +162,6 @@ x-ratelimit-reset-default: 60
 **`.env` additions**:
 ```bash
 CALCOM_EVENT_TYPE_ID=2442700
-CAL_API_VERSION=2024-06-14  # Default for most endpoints
 ```
 
 ### Architecture Changes

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -38,6 +38,7 @@ research was first captured. The production client now pins:
 
 | Endpoint | Required Version |
 |----------|-----------------|
+| `GET /v2/event-types` | `2024-06-14` |
 | `GET /v2/slots` | `2024-09-04` |
 | `POST /v2/bookings` | `2026-02-25` |
 | `POST /v2/bookings/{bookingUid}/cancel` | `2026-02-25` |
@@ -105,6 +106,10 @@ x-ratelimit-reset-default: 60
 ```
 
 **Limit**: 120 requests per minute (per API key)
+
+Cal.com responses observed during research exposed `x-ratelimit-*` headers rather
+than `Retry-After`. The client's bounded `Retry-After` handling is defensive for
+429 responses from Cal.com or an intermediary, not the primary observed signal.
 
 **Implementation Decision**:
 - Implement exponential backoff for 429 errors

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -196,13 +196,15 @@ CALCOM_EVENT_TYPE_ID=2442700
 
 ---
 
-## Test Booking Verification
+## Historical Test Booking Verification
 
 **Booking Created**: `14124132`
 **Time**: 2026-01-01T04:00:00.000+03:00
 **Email**: telegram-user-test@telecalbot.local
 
-**⚠️ ACTION REQUIRED**: Check Google Calendar to verify this test booking appears!
+This records the original research run. The current validator defaults to read-only;
+its opt-in booking smoke test captures the booking UID and cancels the booking
+automatically, failing with a recovery reference if cleanup does not succeed.
 
 ---
 

--- a/research/README.md
+++ b/research/README.md
@@ -14,20 +14,22 @@ The `calcom_api_validator.py` script tests critical unknowns about the Cal.com A
 
 ## Running the Research Script
 
-1. **Install dependencies**:
+1. **Install project dependencies**:
    ```bash
-   pip install -r research/requirements.txt
+   uv sync --frozen
    ```
 
 2. **Ensure .env is configured**:
    - `CALCOM_API_KEY` - Your Cal.com API key
    - `CALCOM_EVENT_SLUG` - Event slug (default: "step")
-   - `CAL_API_VERSION` - API version (default: "2024-08-13")
 
 3. **Run the script**:
    ```bash
-   python research/calcom_api_validator.py
+   uv run python research/calcom_api_validator.py
    ```
+
+   Slots and booking API versions are imported from the production Cal.com client;
+   the research-only event-types version is pinned separately.
 
 ## Output
 

--- a/research/README.md
+++ b/research/README.md
@@ -22,6 +22,8 @@ The `calcom_api_validator.py` script tests critical unknowns about the Cal.com A
 2. **Ensure .env is configured**:
    - `CALCOM_API_KEY` - Your Cal.com API key
    - `CALCOM_EVENT_SLUG` - Event slug (default: "step")
+   - `CALCOM_RESEARCH_ALLOW_WRITE` - Set to `true` only when intentionally running
+     the live create/cancel smoke test (default: `false`)
 
 3. **Run the script**:
    ```bash
@@ -36,9 +38,12 @@ The `calcom_api_validator.py` script tests critical unknowns about the Cal.com A
 The script will:
 - Print a detailed summary of findings to stdout
 - Save results to `research/api_research_results.json`
-- Create a test booking (if placeholder email test runs)
+- Skip all booking writes by default
+- When explicitly enabled, create a test booking and cancel it by UID in the same run
 
-**IMPORTANT**: If a test booking is created, check your Google Calendar to verify it appears!
+**IMPORTANT**: The opt-in smoke test touches the configured live Cal.com account. If
+automatic cancellation fails, the script exits with an error and prints the booking UID
+needed for manual cleanup.
 
 ## What to Do After
 

--- a/research/calcom_api_validator.py
+++ b/research/calcom_api_validator.py
@@ -6,7 +6,7 @@ Phase 0 - Critical Research
 This script validates Cal.com API behavior to inform implementation decisions:
 1. Event Type ID discovery
 2. Availability endpoint behavior
-3. Placeholder email acceptance
+3. Placeholder email acceptance with automatic booking cleanup
 4. Rate limits
 5. Meeting method field structure
 """
@@ -28,6 +28,7 @@ class ResearchSettings(BaseSettings):
 
     calcom_api_key: str = ""
     calcom_event_slug: str = "step"
+    calcom_research_allow_write: bool = False
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
@@ -36,6 +37,7 @@ settings = ResearchSettings()
 API_KEY = settings.calcom_api_key
 BASE_URL = "https://api.cal.com/v2"
 EVENT_SLUG = settings.calcom_event_slug
+ALLOW_LIVE_WRITES = settings.calcom_research_allow_write
 EVENT_TYPES_API_VERSION = "2024-06-14"
 SLOTS_API_VERSION = CalComClient.SLOTS_API_VERSION
 BOOKINGS_API_VERSION = CalComClient.BOOKINGS_API_VERSION
@@ -60,6 +62,8 @@ class ResearchResults:
         self.rate_limit_headers = {}
         self.meeting_method_field = None
         self.test_booking_id = None
+        self.test_booking_uid = None
+        self.booking_cleanup_succeeded = None
         self.errors = []
 
     def to_dict(self) -> dict[str, Any]:
@@ -71,6 +75,8 @@ class ResearchResults:
             "rate_limit_headers": self.rate_limit_headers,
             "meeting_method_field": self.meeting_method_field,
             "test_booking_id": self.test_booking_id,
+            "test_booking_uid": self.test_booking_uid,
+            "booking_cleanup_succeeded": self.booking_cleanup_succeeded,
             "errors": self.errors,
         }
 
@@ -142,7 +148,11 @@ class ResearchResults:
             print("6. TEST BOOKING")
             print("-" * 70)
             print(f"✅ Test booking created: {self.test_booking_id}")
-            print("   IMPORTANT: Check Google Calendar to verify sync!")
+            print(f"   UID: {self.test_booking_uid or 'missing'}")
+            if self.booking_cleanup_succeeded:
+                print("✅ Test booking cancelled automatically")
+            elif self.booking_cleanup_succeeded is False:
+                print("❌ Automatic cleanup failed; use the UID above for manual recovery")
             print()
 
         if self.errors:
@@ -282,8 +292,13 @@ async def test_placeholder_email(client: httpx.AsyncClient, results: ResearchRes
         results.errors.append("Placeholder email test skipped - no available slots")
         return
 
+    if not ALLOW_LIVE_WRITES:
+        print("[3/5] Skipping live booking test (CALCOM_RESEARCH_ALLOW_WRITE is not true)")
+        return
+
     print("[3/5] Testing placeholder email acceptance...")
 
+    booking_uid = None
     try:
         # Get first available slot
         slots = results.availability_sample
@@ -322,13 +337,27 @@ async def test_placeholder_email(client: httpx.AsyncClient, results: ResearchRes
 
         if response.status_code == 201:
             data = response.json()
-            results.test_booking_id = data.get("data", {}).get("id")
+            booking_data = data.get("data", {})
+            results.test_booking_id = booking_data.get("id")
+            results.test_booking_uid = booking_data.get("uid")
+            if isinstance(results.test_booking_uid, str) and results.test_booking_uid:
+                booking_uid = results.test_booking_uid
+            else:
+                results.booking_cleanup_succeeded = False
+                error_msg = (
+                    "Test booking was created without a UID; automatic cleanup is impossible "
+                    f"(booking ID: {results.test_booking_id})"
+                )
+                print(f"  ❌ {error_msg}")
+                results.errors.append(error_msg)
+
             results.placeholder_email_works = True
-            print(f"  ✅ Placeholder email ACCEPTED - Booking ID: {results.test_booking_id}")
-            print("  ⚠️  IMPORTANT: Check Google Calendar to verify this booking!")
+            print(
+                "  ✅ Placeholder email ACCEPTED - "
+                f"Booking ID: {results.test_booking_id}, UID: {results.test_booking_uid}"
+            )
 
             # Try to identify meeting method field
-            booking_data = data.get("data", {})
             if "meetingUrl" in booking_data:
                 results.meeting_method_field = "meetingUrl"
             elif "metadata" in booking_data and "meeting_method" in booking_data["metadata"]:
@@ -353,6 +382,33 @@ async def test_placeholder_email(client: httpx.AsyncClient, results: ResearchRes
     except Exception as e:
         print(f"  ❌ Error: {e}")
         results.errors.append(f"Placeholder email test error: {str(e)}")
+    finally:
+        if booking_uid:
+            await cancel_test_booking(client, booking_uid, results)
+
+
+async def cancel_test_booking(
+    client: httpx.AsyncClient,
+    booking_uid: str,
+    results: ResearchResults,
+) -> None:
+    """Cancel a live research booking and retain its UID if cleanup fails."""
+    print(f"  Cleaning up test booking UID: {booking_uid}...")
+    try:
+        response = await client.post(
+            f"/bookings/{booking_uid}/cancel",
+            json={},
+            headers=api_headers(BOOKINGS_API_VERSION),
+        )
+        response.raise_for_status()
+    except Exception as error:
+        results.booking_cleanup_succeeded = False
+        error_msg = f"Test booking cleanup failed for UID {booking_uid}: {error}"
+        print(f"  ❌ {error_msg}")
+        results.errors.append(error_msg)
+    else:
+        results.booking_cleanup_succeeded = True
+        print("  ✅ Test booking cancelled")
 
 
 async def test_rate_limits(client: httpx.AsyncClient, results: ResearchResults):
@@ -423,6 +479,18 @@ async def main():
     # Exit with error code if critical tests failed
     if not results.event_type_id:
         print("❌ CRITICAL: Event Type ID not found - cannot proceed with implementation")
+        sys.exit(1)
+
+    if results.booking_cleanup_succeeded is False:
+        recovery_reference = (
+            f"UID {results.test_booking_uid}"
+            if results.test_booking_uid
+            else f"numeric booking ID {results.test_booking_id}"
+        )
+        print(
+            "❌ CRITICAL: Test booking cleanup failed; "
+            f"manual recovery reference: {recovery_reference}"
+        )
         sys.exit(1)
 
     print("✅ Research complete! Review findings above to inform implementation.")

--- a/research/calcom_api_validator.py
+++ b/research/calcom_api_validator.py
@@ -18,19 +18,36 @@ from datetime import date, timedelta
 from typing import Any
 
 import httpx
-from decouple import config
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from app.services.calcom_client import CalComClient
+
+
+class ResearchSettings(BaseSettings):
+    """Configuration for live Cal.com contract research."""
+
+    calcom_api_key: str = ""
+    calcom_event_slug: str = "step"
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 # Configuration
-API_KEY = config("CALCOM_API_KEY", default="")
+settings = ResearchSettings()
+API_KEY = settings.calcom_api_key
 BASE_URL = "https://api.cal.com/v2"
-API_VERSION = config("CAL_API_VERSION", default="2024-06-14")
-EVENT_SLUG = config("CALCOM_EVENT_SLUG", default="step")
+EVENT_SLUG = settings.calcom_event_slug
+EVENT_TYPES_API_VERSION = "2024-06-14"
+SLOTS_API_VERSION = CalComClient.SLOTS_API_VERSION
+BOOKINGS_API_VERSION = CalComClient.BOOKINGS_API_VERSION
 
-HEADERS = {
-    "Authorization": f"Bearer {API_KEY}",
-    "cal-api-version": API_VERSION,
-    "Content-Type": "application/json"
-}
+
+def api_headers(api_version: str) -> dict[str, str]:
+    """Build headers for one versioned Cal.com endpoint."""
+    return {
+        "Authorization": f"Bearer {API_KEY}",
+        "cal-api-version": api_version,
+        "Content-Type": "application/json",
+    }
 
 
 class ResearchResults:
@@ -63,7 +80,10 @@ class ResearchResults:
         print("CAL.COM API RESEARCH RESULTS")
         print("="*70 + "\n")
 
-        print(f"API Version: {API_VERSION}")
+        print("API Versions:")
+        print(f"  Event types: {EVENT_TYPES_API_VERSION}")
+        print(f"  Slots: {SLOTS_API_VERSION}")
+        print(f"  Bookings: {BOOKINGS_API_VERSION}")
         print(f"Base URL: {BASE_URL}\n")
 
         print("1. EVENT TYPE DISCOVERY")
@@ -163,7 +183,10 @@ async def fetch_event_types(client: httpx.AsyncClient, results: ResearchResults)
     print(f"[1/5] Fetching event types to find '{EVENT_SLUG}'...")
 
     try:
-        response = await client.get("/event-types", headers=HEADERS)
+        response = await client.get(
+            "/event-types",
+            headers=api_headers(EVENT_TYPES_API_VERSION),
+        )
         response.raise_for_status()
 
         data = response.json()
@@ -206,12 +229,16 @@ async def test_availability(client: httpx.AsyncClient, results: ResearchResults)
 
         params = {
             "eventTypeId": results.event_type_id,
-            "startTime": f"{today.isoformat()}T00:00:00Z",
-            "endTime": f"{end_date.isoformat()}T23:59:59Z",
-            "timeZone": "Europe/Moscow"
+            "start": today.isoformat(),
+            "end": end_date.isoformat(),
+            "timeZone": "Europe/Moscow",
         }
 
-        response = await client.get("/slots/available", params=params, headers=HEADERS)
+        response = await client.get(
+            "/slots",
+            params=params,
+            headers=api_headers(SLOTS_API_VERSION),
+        )
         response.raise_for_status()
 
         # Check for rate limit headers
@@ -222,8 +249,15 @@ async def test_availability(client: httpx.AsyncClient, results: ResearchResults)
         data = response.json()
         results.availability_sample = data.get("data", {})
 
-        slot_count = sum(len(times) for times in results.availability_sample.get("slots", {}).values())
-        print(f"  ✅ Availability fetched: {slot_count} slots across {len(results.availability_sample.get('slots', {}))} days")
+        slot_count = sum(
+            len(slots)
+            for slots in results.availability_sample.values()
+            if isinstance(slots, list)
+        )
+        print(
+            f"  ✅ Availability fetched: {slot_count} slots "
+            f"across {len(results.availability_sample)} days"
+        )
 
     except httpx.HTTPStatusError as e:
         error_msg = f"HTTP {e.response.status_code}: {e.response.text}"
@@ -243,7 +277,7 @@ async def test_placeholder_email(client: httpx.AsyncClient, results: ResearchRes
         results.errors.append("Placeholder email test skipped - no event type ID")
         return
 
-    if not results.availability_sample or not results.availability_sample.get("slots"):
+    if not results.availability_sample:
         print("[3/5] Skipping placeholder email test (no available slots)")
         results.errors.append("Placeholder email test skipped - no available slots")
         return
@@ -252,12 +286,15 @@ async def test_placeholder_email(client: httpx.AsyncClient, results: ResearchRes
 
     try:
         # Get first available slot
-        slots = results.availability_sample["slots"]
+        slots = results.availability_sample
         first_date = sorted(slots.keys())[0]
         first_slot = slots[first_date][0]
 
-        # Extract time from slot object (API v2 returns {time: "ISO timestamp"})
-        start_datetime = first_slot.get("time") if isinstance(first_slot, dict) else first_slot
+        # Current slots use "start"; retain "time" for older captured responses.
+        if isinstance(first_slot, dict):
+            start_datetime = first_slot.get("start") or first_slot.get("time")
+        else:
+            start_datetime = first_slot
 
         # Test booking with placeholder email
         test_booking = {
@@ -276,11 +313,12 @@ async def test_placeholder_email(client: httpx.AsyncClient, results: ResearchRes
         }
 
         # Use booking-specific API version header
-        booking_headers = HEADERS.copy()
-        booking_headers["cal-api-version"] = "2024-08-13"
-
         print(f"  Testing booking at: {start_datetime}")
-        response = await client.post("/bookings", json=test_booking, headers=booking_headers)
+        response = await client.post(
+            "/bookings",
+            json=test_booking,
+            headers=api_headers(BOOKINGS_API_VERSION),
+        )
 
         if response.status_code == 201:
             data = response.json()
@@ -330,13 +368,15 @@ async def test_rate_limits(client: httpx.AsyncClient, results: ResearchResults):
         print("  Decision: Use conservative 60 requests/minute ceiling")
 
 
-async def check_api_version(client: httpx.AsyncClient, results: ResearchResults):
+async def check_api_versions(client: httpx.AsyncClient, results: ResearchResults):
     """
     Test 5: Verify API version is current
     """
     print("[5/5] Verifying API version...")
-    print(f"  Using version: {API_VERSION}")
-    print("  ✅ Version header will be sent with all requests")
+    print(f"  Event types: {EVENT_TYPES_API_VERSION}")
+    print(f"  Slots: {SLOTS_API_VERSION}")
+    print(f"  Bookings: {BOOKINGS_API_VERSION}")
+    print("  ✅ Endpoint-specific version headers will be sent")
 
 
 async def save_results(results: ResearchResults):
@@ -372,7 +412,7 @@ async def main():
         await test_availability(client, results)
         await test_placeholder_email(client, results)
         await test_rate_limits(client, results)
-        await check_api_version(client, results)
+        await check_api_versions(client, results)
 
     # Print summary
     results.print_summary()

--- a/research/requirements.txt
+++ b/research/requirements.txt
@@ -1,3 +1,0 @@
-# Research script dependencies
-httpx>=0.25.0
-python-decouple>=3.8

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -422,7 +422,8 @@ class TestSelectTimezone:
     ):
         """With a duration limit, API errors during availability fetch are handled."""
         mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
-        mock_calcom_client.get_availability.side_effect = CalComAPIError(500, "Server error")
+        raw_error = "Server error: token cal_secret_123 failed"
+        mock_calcom_client.get_availability.side_effect = CalComAPIError(500, raw_error)
 
         mock_duration_service = MagicMock()
         mock_duration_service.get_limit.return_value = 30
@@ -438,6 +439,7 @@ class TestSelectTimezone:
         assert result == BookingState.VIEWING_AVAILABILITY
         last_call = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
         assert "извините" in last_call.lower() or "не удалось" in last_call.lower()
+        assert raw_error not in last_call
 
 
 class TestSelectSlot:
@@ -1047,13 +1049,16 @@ class TestConfirmBooking:
     ):
         mock_update_with_query.callback_query.data = "confirm"
         mock_context.user_data = user_data_ready
-        mock_calcom_client.create_booking.side_effect = CalComAPIError(500, "Server error")
+        raw_error = "Server error: token cal_secret_123 failed"
+        mock_calcom_client.create_booking.side_effect = CalComAPIError(500, raw_error)
 
         with patch("app.handlers.booking.settings") as mock_settings:
             mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await confirm_booking(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
+        error_msg = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
+        assert raw_error not in error_msg
 
     @pytest.mark.asyncio
     async def test_shows_dynamic_duration(
@@ -1401,13 +1406,16 @@ class TestCancelBookingCallbacks:
         booking.status = "active"
         booking.title = "Step session"
         booking.calcom_booking_id = 99
+        booking.calcom_booking_uid = "booking_uid_99"
         booking.start = datetime(2026, 1, 6, 7, 0, tzinfo=timezone.utc)
         booking.end = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
         mock_context.bot_data["booking_service"].get_booking_for_user.return_value = booking
 
         await cancel_booking_confirm(mock_update_with_query, mock_context)
 
-        mock_context.bot_data["calcom_client"].cancel_booking.assert_awaited_once_with(99)
+        mock_context.bot_data["calcom_client"].cancel_booking.assert_awaited_once_with(
+            "booking_uid_99"
+        )
         mock_context.bot_data["booking_service"].mark_cancelled.assert_called_once_with(3, 12345)
 
     @pytest.mark.asyncio

--- a/tests/test_calcom_api_validator.py
+++ b/tests/test_calcom_api_validator.py
@@ -1,0 +1,108 @@
+"""Contract tests for the standalone Cal.com research validator."""
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from research import calcom_api_validator as validator
+
+
+def _response(
+    method: str,
+    path: str,
+    payload: dict,
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    request = httpx.Request(method, f"https://api.cal.com/v2{path}")
+    return httpx.Response(
+        status_code,
+        request=request,
+        json=payload,
+        headers=headers,
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_type_research_uses_endpoint_version():
+    client = SimpleNamespace(
+        get=AsyncMock(
+            return_value=_response(
+                "GET",
+                "/event-types",
+                {"data": [{"id": 123, "slug": validator.EVENT_SLUG}]},
+            )
+        )
+    )
+    results = validator.ResearchResults()
+
+    await validator.fetch_event_types(client, results)
+
+    assert client.get.call_args.args == ("/event-types",)
+    assert client.get.call_args.kwargs["headers"]["cal-api-version"] == "2024-06-14"
+    assert results.event_type_id == 123
+
+
+@pytest.mark.asyncio
+async def test_availability_research_uses_current_slots_contract():
+    slots = {
+        "2026-01-01": [{"start": "2026-01-01T10:00:00.000Z"}],
+    }
+    client = SimpleNamespace(
+        get=AsyncMock(
+            return_value=_response(
+                "GET",
+                "/slots",
+                {"data": slots},
+                headers={"x-ratelimit-limit-default": "120"},
+            )
+        )
+    )
+    results = validator.ResearchResults()
+    results.event_type_id = 123
+
+    await validator.test_availability(client, results)
+
+    assert client.get.call_args.args == ("/slots",)
+    kwargs = client.get.call_args.kwargs
+    assert kwargs["headers"]["cal-api-version"] == "2024-09-04"
+    params = kwargs["params"]
+    assert set(params) == {"eventTypeId", "start", "end", "timeZone"}
+    assert params["eventTypeId"] == 123
+    assert params["timeZone"] == "Europe/Moscow"
+    assert date.fromisoformat(params["end"]) - date.fromisoformat(params["start"]) == timedelta(
+        days=7
+    )
+    assert results.availability_sample == slots
+    assert results.rate_limit_headers == {"x-ratelimit-limit-default": "120"}
+
+
+@pytest.mark.asyncio
+async def test_booking_research_uses_current_slot_shape_and_version():
+    client = SimpleNamespace(
+        post=AsyncMock(
+            return_value=_response(
+                "POST",
+                "/bookings",
+                {"data": {"id": 456}},
+                status_code=201,
+            )
+        )
+    )
+    results = validator.ResearchResults()
+    results.event_type_id = 123
+    results.availability_sample = {
+        "2026-01-01": [{"start": "2026-01-01T10:00:00.000Z"}],
+    }
+
+    await validator.test_placeholder_email(client, results)
+
+    assert client.post.call_args.args == ("/bookings",)
+    kwargs = client.post.call_args.kwargs
+    assert kwargs["headers"]["cal-api-version"] == "2026-02-25"
+    assert kwargs["json"]["start"] == "2026-01-01T10:00:00.000Z"
+    assert results.test_booking_id == 456

--- a/tests/test_calcom_api_validator.py
+++ b/tests/test_calcom_api_validator.py
@@ -82,15 +82,40 @@ async def test_availability_research_uses_current_slots_contract():
 
 
 @pytest.mark.asyncio
-async def test_booking_research_uses_current_slot_shape_and_version():
+async def test_booking_research_requires_explicit_live_write_opt_in(monkeypatch):
+    monkeypatch.setattr(validator, "ALLOW_LIVE_WRITES", False)
+    client = SimpleNamespace(post=AsyncMock())
+    results = validator.ResearchResults()
+    results.event_type_id = 123
+    results.availability_sample = {
+        "2026-01-01": [{"start": "2026-01-01T10:00:00.000Z"}],
+    }
+
+    await validator.test_placeholder_email(client, results)
+
+    client.post.assert_not_awaited()
+    assert results.test_booking_id is None
+    assert results.booking_cleanup_succeeded is None
+
+
+@pytest.mark.asyncio
+async def test_booking_research_creates_and_cancels_by_uid(monkeypatch):
+    monkeypatch.setattr(validator, "ALLOW_LIVE_WRITES", True)
     client = SimpleNamespace(
         post=AsyncMock(
-            return_value=_response(
-                "POST",
-                "/bookings",
-                {"data": {"id": 456}},
-                status_code=201,
-            )
+            side_effect=[
+                _response(
+                    "POST",
+                    "/bookings",
+                    {"data": {"id": 456, "uid": "booking_uid_456"}},
+                    status_code=201,
+                ),
+                _response(
+                    "POST",
+                    "/bookings/booking_uid_456/cancel",
+                    {"data": {}},
+                ),
+            ]
         )
     )
     results = validator.ResearchResults()
@@ -101,8 +126,50 @@ async def test_booking_research_uses_current_slot_shape_and_version():
 
     await validator.test_placeholder_email(client, results)
 
-    assert client.post.call_args.args == ("/bookings",)
-    kwargs = client.post.call_args.kwargs
-    assert kwargs["headers"]["cal-api-version"] == "2026-02-25"
-    assert kwargs["json"]["start"] == "2026-01-01T10:00:00.000Z"
+    create_call, cancel_call = client.post.await_args_list
+    assert create_call.args == ("/bookings",)
+    assert create_call.kwargs["headers"]["cal-api-version"] == "2026-02-25"
+    assert create_call.kwargs["json"]["start"] == "2026-01-01T10:00:00.000Z"
+    assert cancel_call.args == ("/bookings/booking_uid_456/cancel",)
+    assert cancel_call.kwargs["headers"]["cal-api-version"] == "2026-02-25"
+    assert cancel_call.kwargs["json"] == {}
     assert results.test_booking_id == 456
+    assert results.test_booking_uid == "booking_uid_456"
+    assert results.booking_cleanup_succeeded is True
+
+
+@pytest.mark.asyncio
+async def test_booking_research_reports_uid_when_cleanup_fails(monkeypatch):
+    monkeypatch.setattr(validator, "ALLOW_LIVE_WRITES", True)
+    client = SimpleNamespace(
+        post=AsyncMock(
+            side_effect=[
+                _response(
+                    "POST",
+                    "/bookings",
+                    {"data": {"id": 456, "uid": "booking_uid_456"}},
+                    status_code=201,
+                ),
+                _response(
+                    "POST",
+                    "/bookings/booking_uid_456/cancel",
+                    {"error": "cleanup failed"},
+                    status_code=500,
+                ),
+            ]
+        )
+    )
+    results = validator.ResearchResults()
+    results.event_type_id = 123
+    results.availability_sample = {
+        "2026-01-01": [{"start": "2026-01-01T10:00:00.000Z"}],
+    }
+
+    await validator.test_placeholder_email(client, results)
+
+    assert results.booking_cleanup_succeeded is False
+    assert results.test_booking_uid == "booking_uid_456"
+    assert any(
+        "booking_uid_456" in error and "cleanup failed" in error.lower()
+        for error in results.errors
+    )

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -175,11 +175,19 @@ class TestCalComClient:
             mock_request.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_availability_sends_requested_duration(self, client):
-        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
-            mock_request.return_value = {"status": "success", "data": {"slots": {}}}
+    async def test_get_availability_uses_current_slots_endpoint_version(self, client):
+        """Availability requests pin the API version required by /v2/slots."""
+        mock_response = {
+            "status": "success",
+            "data": {
+                "2026-01-01": [{"start": "2026-01-01T10:00:00.000+03:00"}],
+            },
+        }
 
-            await client.get_availability(
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+
+            result = await client.get_availability(
                 event_type_id=123,
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
@@ -187,7 +195,19 @@ class TestCalComClient:
                 duration_minutes=120,
             )
 
-        assert mock_request.call_args.kwargs["params"]["duration"] == 120
+        method, path = mock_request.call_args.args
+        kwargs = mock_request.call_args.kwargs
+        assert method == "GET"
+        assert path == "/slots"
+        assert kwargs["api_version"] == CalComClient.SLOTS_API_VERSION
+        assert kwargs["params"] == {
+            "eventTypeId": 123,
+            "start": "2026-01-01",
+            "end": "2026-01-07",
+            "timeZone": "Europe/Moscow",
+            "duration": 120,
+        }
+        assert result.slots["2026-01-01"][0].time == "2026-01-01T10:00:00.000+03:00"
 
     @pytest.mark.asyncio
     async def test_get_availability_omits_duration_without_override(self, client):
@@ -365,6 +385,7 @@ class TestCalComClient:
             assert isinstance(result, BookingResponse)
             assert result.id == 123
             assert result.status == "accepted"
+            assert mock_request.call_args.kwargs["api_version"] == CalComClient.BOOKINGS_API_VERSION
 
     @pytest.mark.asyncio
     async def test_create_booking_omits_none_duration_override(self, client):
@@ -473,11 +494,15 @@ class TestCalComClient:
             assert mock_request.call_count == 1
 
             mock_request.return_value = {"status": "success", "data": {}}
-            await client.cancel_booking(123)
+            await client.cancel_booking("booking_uid_123")
 
             method, path = mock_request.call_args_list[1][0]
             assert method == "POST"
-            assert path == "/bookings/123/cancel"
+            assert path == "/bookings/booking_uid_123/cancel"
+            assert (
+                mock_request.call_args_list[1].kwargs["api_version"]
+                == CalComClient.BOOKINGS_API_VERSION
+            )
 
             mock_request.return_value = avail_response
             await client.get_availability(
@@ -570,6 +595,37 @@ class TestCalComClientRetry:
             assert result == {"status": "success", "data": {"ok": True}}
             assert mock_request.call_count == 2
             mock_sleep.assert_awaited_once_with(0.5)
+
+    @pytest.mark.asyncio
+    async def test_uses_retry_after_header_for_rate_limits(self, client):
+        request = httpx.Request("GET", "https://api.cal.com/v2/test")
+        rate_limited = httpx.Response(
+            429,
+            text="rate limited",
+            headers={"Retry-After": "2"},
+            request=request,
+        )
+
+        with (
+            patch.object(client._client, "request", new_callable=AsyncMock) as mock_request,
+            patch("app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            mock_request.side_effect = [
+                httpx.HTTPStatusError(
+                    message="rate limited",
+                    request=request,
+                    response=rate_limited,
+                ),
+                httpx.Response(
+                    200,
+                    request=request,
+                    json={"status": "success", "data": {"ok": True}},
+                ),
+            ]
+
+            await client._request("GET", "/test")
+
+        mock_sleep.assert_awaited_once_with(2.0)
 
     @pytest.mark.asyncio
     async def test_does_not_retry_non_retryable_status(self, client):

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -141,9 +141,11 @@ class TestCalComClient:
         """Create a CalComClient instance for testing."""
         return CalComClient(
             api_key="test_key",
-            api_version="2024-06-14",
             cache_ttl=300,
         )
+
+    def test_client_has_no_ambient_api_version_header(self, client):
+        assert "cal-api-version" not in client._client.headers
 
     @pytest.mark.asyncio
     async def test_get_availability_returns_parsed_response(self, client):
@@ -199,7 +201,7 @@ class TestCalComClient:
         kwargs = mock_request.call_args.kwargs
         assert method == "GET"
         assert path == "/slots"
-        assert kwargs["api_version"] == CalComClient.SLOTS_API_VERSION
+        assert kwargs["api_version"] == "2024-09-04"
         assert kwargs["params"] == {
             "eventTypeId": 123,
             "start": "2026-01-01",
@@ -208,6 +210,22 @@ class TestCalComClient:
             "duration": 120,
         }
         assert result.slots["2026-01-01"][0].time == "2026-01-01T10:00:00.000+03:00"
+
+    def test_parse_availability_ignores_malformed_slot_shapes(self, client):
+        result = client._parse_availability(
+            {
+                "2026-01-01": {"start": "2026-01-01T10:00:00.000Z"},
+                "2026-01-02": [
+                    None,
+                    123,
+                    {"start": "2026-01-02T10:00:00.000Z"},
+                ],
+            }
+        )
+
+        assert result.slots == {
+            "2026-01-02": [TimeSlot(time="2026-01-02T10:00:00.000Z")],
+        }
 
     @pytest.mark.asyncio
     async def test_get_availability_omits_duration_without_override(self, client):
@@ -385,7 +403,7 @@ class TestCalComClient:
             assert isinstance(result, BookingResponse)
             assert result.id == 123
             assert result.status == "accepted"
-            assert mock_request.call_args.kwargs["api_version"] == CalComClient.BOOKINGS_API_VERSION
+            assert mock_request.call_args.kwargs["api_version"] == "2026-02-25"
 
     @pytest.mark.asyncio
     async def test_create_booking_omits_none_duration_override(self, client):
@@ -499,10 +517,7 @@ class TestCalComClient:
             method, path = mock_request.call_args_list[1][0]
             assert method == "POST"
             assert path == "/bookings/booking_uid_123/cancel"
-            assert (
-                mock_request.call_args_list[1].kwargs["api_version"]
-                == CalComClient.BOOKINGS_API_VERSION
-            )
+            assert mock_request.call_args_list[1].kwargs["api_version"] == "2026-02-25"
 
             mock_request.return_value = avail_response
             await client.get_availability(
@@ -522,7 +537,6 @@ class TestCalComClientRetry:
     def client(self):
         return CalComClient(
             api_key="test_key",
-            api_version="2024-06-14",
             cache_ttl=300,
         )
 
@@ -566,7 +580,12 @@ class TestCalComClientRetry:
             return_value=response,
         ):
             with pytest.raises(CalComAPIError) as exc_info:
-                await client._request("POST", "/bookings", json={})
+                await client._request(
+                    "POST",
+                    "/bookings",
+                    api_version="2026-02-25",
+                    json={},
+                )
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.code == "email_domain_cannot_receive_mail"
@@ -590,11 +609,41 @@ class TestCalComClientRetry:
                 ),
             ]
 
-            result = await client._request("GET", "/test")
+            result = await client._request(
+                "GET",
+                "/test",
+                api_version="test-version",
+            )
 
             assert result == {"status": "success", "data": {"ok": True}}
             assert mock_request.call_count == 2
             mock_sleep.assert_awaited_once_with(0.5)
+
+    @pytest.mark.asyncio
+    async def test_request_sends_explicit_api_version_header(self, client):
+        response = httpx.Response(
+            200,
+            request=httpx.Request("GET", "https://api.cal.com/v2/test"),
+            json={"status": "success", "data": {"ok": True}},
+        )
+
+        with patch.object(
+            client._client,
+            "request",
+            new_callable=AsyncMock,
+            return_value=response,
+        ) as mock_request:
+            await client._request(
+                "GET",
+                "/test",
+                api_version="2024-09-04",
+                headers={"X-Request-ID": "request-1"},
+            )
+
+        assert mock_request.call_args.kwargs["headers"] == {
+            "X-Request-ID": "request-1",
+            "cal-api-version": "2024-09-04",
+        }
 
     @pytest.mark.asyncio
     async def test_uses_retry_after_header_for_rate_limits(self, client):
@@ -623,9 +672,31 @@ class TestCalComClientRetry:
                 ),
             ]
 
-            await client._request("GET", "/test")
+            await client._request(
+                "GET",
+                "/test",
+                api_version="test-version",
+            )
 
         mock_sleep.assert_awaited_once_with(2.0)
+
+    @pytest.mark.parametrize(
+        ("retry_after", "expected_delay"),
+        [
+            ("300", 10.0),
+            ("inf", 0.5),
+            ("nan", 0.5),
+            ("-2", 0.0),
+            ("Wed, 21 Oct 2015 07:28:00 GMT", 0.5),
+        ],
+    )
+    def test_bounds_retry_after_delay(self, client, retry_after, expected_delay):
+        response = httpx.Response(
+            429,
+            headers={"Retry-After": retry_after},
+        )
+
+        assert client._retry_delay_seconds(response, 0.5) == expected_delay
 
     @pytest.mark.asyncio
     async def test_does_not_retry_non_retryable_status(self, client):
@@ -640,7 +711,11 @@ class TestCalComClientRetry:
             mock_request.side_effect = [self._http_status_error(400, "bad request")]
 
             with pytest.raises(CalComAPIError) as exc_info:
-                await client._request("GET", "/test")
+                await client._request(
+                    "GET",
+                    "/test",
+                    api_version="test-version",
+                )
 
             assert exc_info.value.status_code == 400
             assert mock_request.call_count == 1
@@ -661,7 +736,11 @@ class TestCalComClientRetry:
             ]
 
             with pytest.raises(CalComAPIError) as exc_info:
-                await client._request("GET", "/test")
+                await client._request(
+                    "GET",
+                    "/test",
+                    api_version="test-version",
+                )
 
             assert exc_info.value.status_code == 503
             assert mock_request.call_count == 4
@@ -676,7 +755,6 @@ class TestCalComClientClose:
         """Client can be closed properly."""
         client = CalComClient(
             api_key="test_key",
-            api_version="2024-06-14",
         )
 
         with patch.object(client._client, "aclose", new_callable=AsyncMock) as mock:
@@ -688,7 +766,6 @@ class TestCalComClientClose:
         """Client works as async context manager."""
         async with CalComClient(
             api_key="test_key",
-            api_version="2024-06-14",
         ) as client:
             assert client is not None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ def test_config_defaults():
 
     settings = Settings()
 
-    assert settings.cal_api_version == "2024-06-14"
+    assert "cal_api_version" not in Settings.model_fields
     assert settings.calcom_event_slug == "step"
     assert settings.database_path == "telecalbot.db"
     assert settings.log_level == "INFO"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ def test_config_defaults():
 
     settings = Settings()
 
-    assert settings.cal_api_version == "2024-08-13"
+    assert settings.cal_api_version == "2024-06-14"
     assert settings.calcom_event_slug == "step"
     assert settings.database_path == "telecalbot.db"
     assert settings.log_level == "INFO"


### PR DESCRIPTION
## Summary
- Pins the documented endpoint-specific Cal.com API versions for slots and bookings/cancellation.
- Moves availability to the current `/v2/slots` contract while normalizing current and legacy slot shapes.
- Requires every low-level client request to declare its API version and removes the ineffective global `CAL_API_VERSION` setting.
- Honors numeric `Retry-After` values with finite validation and a 10-second ceiling; HTTP-date values fall back to exponential backoff.
- Ignores malformed availability containers/items without fabricating slots or raising raw parsing errors.
- Keeps raw Cal.com failure bodies out of user-facing booking messages and uses stored booking UIDs for cancellation.
- Reconciles `research/FINDINGS.md` with the verified current contract.
- Updates the research validator to share production endpoint versions, default to read-only, and clean up opt-in live bookings by UID.

## Issue
Maps to and closes #55. Roadmap meta-issue #3 remains open.

## Cleanup afterward
- Periodically re-check Cal.com documentation for future `cal-api-version` changes.
- Move the opt-in live contract smoke to dedicated test credentials if it is automated later.

## Validation
- `uv sync --frozen`
- `uv run ruff check .`
- `uv run pytest tests/ -v` (257 passed)
- `docker build -t telecalbot:ci .`
- Docker import smoke: `import-ok`
- Docker migration smoke: `migrations-ok`

The opt-in live validator was not run, so no live Cal.com booking was created.
