### PR TITLE
[codex] Persist booking timezone preferences

### DIFF
--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -4,6 +4,7 @@ import logging
 import secrets
 from datetime import date, datetime, timedelta, timezone
 from enum import IntEnum, auto
+from types import SimpleNamespace
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.error import BadRequest
@@ -28,6 +29,7 @@ from app.services.calcom_client import (
     CalComClient,
 )
 from app.services.duration_limit import DurationLimitService
+from app.services.user_preferences import UserPreferenceService
 from app.services.whitelist import WhitelistService
 
 logger = logging.getLogger(__name__)
@@ -114,6 +116,21 @@ class BookingState(IntEnum):
     EMAIL_DECISION = auto()
     ENTERING_EMAIL = auto()
     CONFIRMING = auto()
+
+
+class _MessageReplyTarget:
+    """Adapter for reusing callback edit flow from a command message."""
+
+    def __init__(self, message, user_id: int, prefix: str | None = None):
+        self.message = message
+        self.from_user = SimpleNamespace(id=user_id)
+        self._prefix = prefix
+
+    async def edit_message_text(self, text: str, reply_markup=None) -> None:
+        if self._prefix is not None:
+            text = f"{self._prefix}\n\n{text}"
+            self._prefix = None
+        await self.message.reply_text(text, reply_markup=reply_markup)
 
 
 def _is_non_editable_message_error(error: BadRequest) -> bool:
@@ -333,6 +350,29 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         return ConversationHandler.END
 
     _refresh_booking_timeout_reminder(context, update.effective_user.id)
+
+    preference_service: UserPreferenceService | None = context.bot_data.get(
+        "user_preference_service"
+    )
+    if preference_service is not None:
+        try:
+            preference = preference_service.get_timezone(update.effective_user.id)
+        except Exception:
+            logger.exception(
+                "Failed to load timezone preference for user_id=%s",
+                update.effective_user.id,
+            )
+        else:
+            if preference is not None:
+                context.user_data["timezone"] = preference.timezone
+                context.user_data["offset_days"] = 0
+                target = _MessageReplyTarget(
+                    update.message,
+                    update.effective_user.id,
+                    prefix=f"Используем сохраненный часовой пояс: {preference.timezone}.",
+                )
+                return await _handle_duration_selection(target, context)
+
     keyboard = build_timezone_keyboard()
     await update.message.reply_text(
         "Выберите ваш часовой пояс:",
@@ -354,6 +394,18 @@ async def select_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     timezone_id = query.data.split(":", 1)[1]
     context.user_data["timezone"] = timezone_id
     context.user_data["offset_days"] = 0
+    preference_service: UserPreferenceService | None = context.bot_data.get(
+        "user_preference_service"
+    )
+    if preference_service is not None:
+        try:
+            preference_service.set_timezone(query.from_user.id, timezone_id)
+        except Exception:
+            logger.exception(
+                "Failed to persist timezone preference for user_id=%s timezone=%s",
+                query.from_user.id,
+                timezone_id,
+            )
     _refresh_booking_timeout_reminder(context, query.from_user.id)
 
     return await _handle_duration_selection(query, context)
@@ -1108,6 +1160,7 @@ def build_duration_keyboard(max_duration: int | None = None) -> InlineKeyboardMa
         for minutes, label in DURATION_OPTIONS.items()
         if max_duration is None or minutes <= max_duration
     ]
+    buttons.append([InlineKeyboardButton(TIMEZONE_BUTTON_LABEL, callback_data="change_tz")])
     buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
     return InlineKeyboardMarkup(buttons)
 
@@ -1276,6 +1329,7 @@ def create_booking_conversation_handler() -> ConversationHandler:
                     pattern=f"^{FIFTH_STEP_CONFIRM_CALLBACK}$",
                 ),
                 CallbackQueryHandler(change_duration, pattern=f"^{CHANGE_DURATION_CALLBACK}$"),
+                CallbackQueryHandler(change_timezone, pattern="^change_tz$"),
                 CallbackQueryHandler(cancel, pattern="^cancel$"),
             ],
             BookingState.VIEWING_AVAILABILITY: [

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -65,6 +65,7 @@ MAX_NAME_LENGTH = 100
 DURATION_OPTIONS = {
     minutes: f"{minutes} минут" for minutes in SUPPORTED_BOOKING_DURATIONS
 }
+SUPPORTED_TIMEZONE_IDS = frozenset(timezone_id for timezone_id, _ in RUSSIAN_TIMEZONES)
 FIFTH_STEP_RESTRICTION_TEXT = (
     "двухчасовые встречи предназначены только для работы по 5-му шагу."
 )
@@ -125,12 +126,15 @@ class _MessageReplyTarget:
         self.message = message
         self.from_user = SimpleNamespace(id=user_id)
         self._prefix = prefix
+        self._sent = None
 
     async def edit_message_text(self, text: str, reply_markup=None) -> None:
         if self._prefix is not None:
             text = f"{self._prefix}\n\n{text}"
-            self._prefix = None
-        await self.message.reply_text(text, reply_markup=reply_markup)
+        if self._sent is None:
+            self._sent = await self.message.reply_text(text, reply_markup=reply_markup)
+            return
+        await self._sent.edit_text(text, reply_markup=reply_markup)
 
 
 def _is_non_editable_message_error(error: BadRequest) -> bool:
@@ -363,7 +367,7 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
                 update.effective_user.id,
             )
         else:
-            if preference is not None:
+            if preference is not None and preference.timezone in SUPPORTED_TIMEZONE_IDS:
                 context.user_data["timezone"] = preference.timezone
                 context.user_data["offset_days"] = 0
                 target = _MessageReplyTarget(
@@ -372,6 +376,12 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
                     prefix=f"Используем сохраненный часовой пояс: {preference.timezone}.",
                 )
                 return await _handle_duration_selection(target, context)
+            if preference is not None:
+                logger.warning(
+                    "Ignoring unsupported timezone preference for user_id=%s timezone=%s",
+                    update.effective_user.id,
+                    preference.timezone,
+                )
 
     keyboard = build_timezone_keyboard()
     await update.message.reply_text(
@@ -392,12 +402,13 @@ async def select_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await query.answer()
 
     timezone_id = query.data.split(":", 1)[1]
+    previous_timezone = context.user_data.get("timezone")
     context.user_data["timezone"] = timezone_id
     context.user_data["offset_days"] = 0
     preference_service: UserPreferenceService | None = context.bot_data.get(
         "user_preference_service"
     )
-    if preference_service is not None:
+    if preference_service is not None and timezone_id != previous_timezone:
         try:
             preference_service.set_timezone(query.from_user.id, timezone_id)
         except Exception:
@@ -602,6 +613,9 @@ async def _show_availability(
                             "Попробовать снова",
                             callback_data=f"tz:{timezone_id}",
                         ),
+                    ],
+                    [
+                        InlineKeyboardButton(TIMEZONE_BUTTON_LABEL, callback_data="change_tz"),
                         InlineKeyboardButton("Отмена", callback_data="cancel"),
                     ]
                 ]

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from app.handlers.duration_limit import (
 from app.services.booking_service import BookingService
 from app.services.calcom_client import CalComClient
 from app.services.duration_limit import DurationLimitService
+from app.services.user_preferences import UserPreferenceService
 from app.services.whitelist import WhitelistService
 from app.webhook_server import run_webhook
 
@@ -66,6 +67,7 @@ def create_application() -> Application:
 
     # Inject services
     application.bot_data["whitelist_service"] = WhitelistService(db)
+    application.bot_data["user_preference_service"] = UserPreferenceService(db)
     application.bot_data["duration_limit_service"] = DurationLimitService(db)
     application.bot_data["booking_service"] = BookingService(db)
     application.bot_data["calcom_client"] = CalComClient(api_key=settings.calcom_api_key)

--- a/app/services/user_preferences.py
+++ b/app/services/user_preferences.py
@@ -1,0 +1,42 @@
+"""Service for persisted user profile preferences."""
+
+from datetime import datetime, timezone
+
+from app.database import Database
+from app.database.models import UserPreference
+
+
+class UserPreferenceService:
+    """Store and retrieve user-level profile preferences."""
+
+    def __init__(self, db: Database):
+        self.db = db
+
+    def get_timezone(self, telegram_id: int) -> UserPreference | None:
+        """Return the persisted timezone preference for a user, if present."""
+        row = self.db.execute_one(
+            "SELECT * FROM user_preferences WHERE telegram_id = ?",
+            (telegram_id,),
+        )
+        if row is None:
+            return None
+
+        return UserPreference(
+            telegram_id=row["telegram_id"],
+            timezone=row["timezone"],
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def set_timezone(self, telegram_id: int, timezone_id: str) -> None:
+        """Create or update the user's selected timezone."""
+        now = datetime.now(timezone.utc).isoformat()
+        self.db.execute_write(
+            """
+            INSERT INTO user_preferences (telegram_id, timezone, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(telegram_id) DO UPDATE SET
+                timezone = excluded.timezone,
+                updated_at = excluded.updated_at
+            """,
+            (telegram_id, timezone_id, now),
+        )

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -9,6 +9,7 @@ from telegram.ext import ConversationHandler
 
 from app.config import ResolvedEventType
 from app.constants import RUSSIAN_TIMEZONES
+from app.database.models import UserPreference
 from app.handlers.booking import (
     BookingState,
     _booking_reference,
@@ -372,7 +373,11 @@ class TestBookCommand:
         whitelist_service = MagicMock()
         whitelist_service.is_whitelisted.return_value = True
         preference_service = MagicMock()
-        preference_service.get_timezone.return_value = MagicMock(timezone="Europe/Moscow")
+        preference_service.get_timezone.return_value = UserPreference(
+            telegram_id=12345,
+            timezone="Europe/Moscow",
+            updated_at=datetime.now(timezone.utc),
+        )
         mock_context.bot_data["whitelist_service"] = whitelist_service
         mock_context.bot_data["user_preference_service"] = preference_service
 
@@ -397,10 +402,16 @@ class TestBookCommand:
         whitelist_service = MagicMock()
         whitelist_service.is_whitelisted.return_value = True
         preference_service = MagicMock()
-        preference_service.get_timezone.return_value = MagicMock(timezone="Europe/Moscow")
+        preference_service.get_timezone.return_value = UserPreference(
+            telegram_id=12345,
+            timezone="Europe/Moscow",
+            updated_at=datetime.now(timezone.utc),
+        )
         duration_service = MagicMock()
         duration_service.get_limit.return_value = 30
         mock_calcom_client.get_availability.return_value = availability_response
+        sent_message = AsyncMock()
+        mock_update.message.reply_text.return_value = sent_message
         mock_context.bot_data["whitelist_service"] = whitelist_service
         mock_context.bot_data["user_preference_service"] = preference_service
         mock_context.bot_data["duration_limit_service"] = duration_service
@@ -414,6 +425,75 @@ class TestBookCommand:
         assert mock_context.user_data["duration"] == 30
         mock_calcom_client.get_availability.assert_called_once()
         assert mock_calcom_client.get_availability.call_args.kwargs["timezone"] == "Europe/Moscow"
+        mock_update.message.reply_text.assert_awaited_once()
+        assert "Загружаю" in mock_update.message.reply_text.call_args.args[0]
+        sent_message.edit_text.assert_awaited_once()
+        final_text = sent_message.edit_text.call_args.args[0]
+        assert "Используем сохраненный часовой пояс: Europe/Moscow" in final_text
+        assert "Доступное время" in final_text
+
+    @pytest.mark.asyncio
+    async def test_invalid_saved_timezone_falls_back_to_picker(self, mock_update, mock_context):
+        preference_service = MagicMock()
+        preference_service.get_timezone.return_value = UserPreference(
+            telegram_id=12345,
+            timezone="Europe/Removed",
+            updated_at=datetime.now(timezone.utc),
+        )
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = True
+        mock_context.bot_data["user_preference_service"] = preference_service
+
+        result = await book_command(mock_update, mock_context)
+
+        assert result == BookingState.SELECTING_TIMEZONE
+        assert "timezone" not in mock_context.user_data
+        reply_markup = mock_update.message.reply_text.call_args.kwargs["reply_markup"]
+        callback_data = [
+            button.callback_data for row in reply_markup.inline_keyboard for button in row
+        ]
+        assert "tz:Europe/Moscow" in callback_data
+
+    @pytest.mark.asyncio
+    async def test_preference_load_failure_falls_back_to_picker(self, mock_update, mock_context):
+        preference_service = MagicMock()
+        preference_service.get_timezone.side_effect = RuntimeError("database unavailable")
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = True
+        mock_context.bot_data["user_preference_service"] = preference_service
+
+        result = await book_command(mock_update, mock_context)
+
+        assert result == BookingState.SELECTING_TIMEZONE
+        assert "timezone" not in mock_context.user_data
+
+    @pytest.mark.asyncio
+    async def test_returning_user_can_change_and_persist_timezone(
+        self,
+        mock_update,
+        mock_update_with_query,
+        mock_context,
+    ):
+        preference_service = MagicMock()
+        preference_service.get_timezone.return_value = UserPreference(
+            telegram_id=12345,
+            timezone="Europe/Moscow",
+            updated_at=datetime.now(timezone.utc),
+        )
+        mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = True
+        mock_context.bot_data["user_preference_service"] = preference_service
+
+        assert await book_command(mock_update, mock_context) == BookingState.SELECTING_DURATION
+        assert (
+            await change_timezone(mock_update_with_query, mock_context)
+            == BookingState.SELECTING_TIMEZONE
+        )
+        mock_update_with_query.callback_query.from_user.id = 12345
+        mock_update_with_query.callback_query.data = "tz:Asia/Yekaterinburg"
+
+        result = await select_timezone(mock_update_with_query, mock_context)
+
+        assert result == BookingState.SELECTING_DURATION
+        assert mock_context.user_data["timezone"] == "Asia/Yekaterinburg"
+        preference_service.set_timezone.assert_called_once_with(12345, "Asia/Yekaterinburg")
 
 
 class TestSelectTimezone:
@@ -446,6 +526,40 @@ class TestSelectTimezone:
         await select_timezone(mock_update_with_query, mock_context)
 
         preference_service.set_timezone.assert_called_once_with(12345, "Europe/Moscow")
+
+    @pytest.mark.asyncio
+    async def test_does_not_rewrite_unchanged_timezone(
+        self, mock_update_with_query, mock_context, mock_calcom_client
+    ):
+        preference_service = MagicMock()
+        mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
+        mock_update_with_query.callback_query.from_user.id = 12345
+        mock_context.user_data["timezone"] = "Europe/Moscow"
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom_client,
+            "user_preference_service": preference_service,
+        }
+
+        await select_timezone(mock_update_with_query, mock_context)
+
+        preference_service.set_timezone.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preference_write_failure_does_not_block_booking(
+        self, mock_update_with_query, mock_context, mock_calcom_client
+    ):
+        preference_service = MagicMock()
+        preference_service.set_timezone.side_effect = RuntimeError("database unavailable")
+        mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom_client,
+            "user_preference_service": preference_service,
+        }
+
+        result = await select_timezone(mock_update_with_query, mock_context)
+
+        assert result == BookingState.SELECTING_DURATION
+        assert mock_context.user_data["timezone"] == "Europe/Moscow"
 
     @pytest.mark.asyncio
     async def test_returns_selecting_duration_when_no_limit(
@@ -519,6 +633,13 @@ class TestSelectTimezone:
         last_call = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
         assert "извините" in last_call.lower() or "не удалось" in last_call.lower()
         assert raw_error not in last_call
+        reply_markup = mock_update_with_query.callback_query.edit_message_text.call_args.kwargs[
+            "reply_markup"
+        ]
+        callback_data = [
+            button.callback_data for row in reply_markup.inline_keyboard for button in row
+        ]
+        assert "change_tz" in callback_data
 
 
 class TestSelectSlot:

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -17,6 +17,7 @@ from app.handlers.booking import (
     booking_timeout,
     build_availability_keyboard,
     build_cancel_booking_keyboard,
+    build_duration_keyboard,
     build_timezone_keyboard,
     cancel,
     cancel_booking_back,
@@ -215,6 +216,17 @@ class TestBuildTimezoneKeyboard:
         assert len(tz_buttons) == len(RUSSIAN_TIMEZONES)
 
 
+class TestBuildDurationKeyboard:
+    def test_has_timezone_change_button(self):
+        keyboard = build_duration_keyboard()
+        all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
+
+        assert any(
+            btn.text == "Часовой пояс" and btn.callback_data == "change_tz"
+            for btn in all_buttons
+        )
+
+
 class TestBuildAvailabilityKeyboard:
     def test_shows_day_headers(self, availability_response):
         keyboard = build_availability_keyboard(availability_response.slots)
@@ -353,6 +365,56 @@ class TestBookCommand:
         call_kwargs = mock_update.message.reply_text.call_args[1]
         assert "reply_markup" in call_kwargs
 
+    @pytest.mark.asyncio
+    async def test_skips_timezone_selection_for_returning_user(
+        self, mock_update, mock_context
+    ):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = True
+        preference_service = MagicMock()
+        preference_service.get_timezone.return_value = MagicMock(timezone="Europe/Moscow")
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+        mock_context.bot_data["user_preference_service"] = preference_service
+
+        result = await book_command(mock_update, mock_context)
+
+        assert result == BookingState.SELECTING_DURATION
+        assert mock_context.user_data["timezone"] == "Europe/Moscow"
+        assert mock_context.user_data["offset_days"] == 0
+        message_text = mock_update.message.reply_text.call_args[0][0]
+        assert "Europe/Moscow" in message_text
+        all_buttons = [
+            btn
+            for row in mock_update.message.reply_text.call_args[1]["reply_markup"].inline_keyboard
+            for btn in row
+        ]
+        assert any(btn.callback_data == "change_tz" for btn in all_buttons)
+
+    @pytest.mark.asyncio
+    async def test_returning_user_with_duration_limit_goes_to_availability(
+        self, mock_update, mock_context, mock_calcom_client, availability_response
+    ):
+        whitelist_service = MagicMock()
+        whitelist_service.is_whitelisted.return_value = True
+        preference_service = MagicMock()
+        preference_service.get_timezone.return_value = MagicMock(timezone="Europe/Moscow")
+        duration_service = MagicMock()
+        duration_service.get_limit.return_value = 30
+        mock_calcom_client.get_availability.return_value = availability_response
+        mock_context.bot_data["whitelist_service"] = whitelist_service
+        mock_context.bot_data["user_preference_service"] = preference_service
+        mock_context.bot_data["duration_limit_service"] = duration_service
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
+            result = await book_command(mock_update, mock_context)
+
+        assert result == BookingState.VIEWING_AVAILABILITY
+        assert mock_context.user_data["timezone"] == "Europe/Moscow"
+        assert mock_context.user_data["duration"] == 30
+        mock_calcom_client.get_availability.assert_called_once()
+        assert mock_calcom_client.get_availability.call_args.kwargs["timezone"] == "Europe/Moscow"
+
 
 class TestSelectTimezone:
     @pytest.mark.asyncio
@@ -360,6 +422,7 @@ class TestSelectTimezone:
         self, mock_update_with_query, mock_context, mock_calcom_client, availability_response
     ):
         mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
+        mock_update_with_query.callback_query.from_user.id = 12345
         mock_calcom_client.get_availability.return_value = availability_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
@@ -367,6 +430,22 @@ class TestSelectTimezone:
             await select_timezone(mock_update_with_query, mock_context)
 
         assert mock_context.user_data["timezone"] == "Europe/Moscow"
+
+    @pytest.mark.asyncio
+    async def test_persists_selected_timezone(
+        self, mock_update_with_query, mock_context, mock_calcom_client
+    ):
+        preference_service = MagicMock()
+        mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
+        mock_update_with_query.callback_query.from_user.id = 12345
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom_client,
+            "user_preference_service": preference_service,
+        }
+
+        await select_timezone(mock_update_with_query, mock_context)
+
+        preference_service.set_timezone.assert_called_once_with(12345, "Europe/Moscow")
 
     @pytest.mark.asyncio
     async def test_returns_selecting_duration_when_no_limit(

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -238,7 +238,13 @@ class TestFifthStepAcknowledgement:
             for row in call.kwargs["reply_markup"].inline_keyboard
             for button in row
         ]
-        assert button_texts == ["30 минут", "60 минут", "120 минут", "Отмена"]
+        assert button_texts == [
+            "30 минут",
+            "60 минут",
+            "120 минут",
+            "Часовой пояс",
+            "Отмена",
+        ]
 
     @pytest.mark.asyncio
     async def test_stale_acknowledgement_without_pending_duration_returns_to_picker(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -73,6 +73,7 @@ class TestMain:
     ):
         monkeypatch.setattr("app.main.settings.telegram_delivery_mode", "polling")
         app_instance = MagicMock()
+        app_instance.bot_data = {}
         mock_application.builder.return_value.token.return_value.build.return_value = app_instance
 
         main()
@@ -80,6 +81,7 @@ class TestMain:
         mock_setup_logging.assert_called_once()
         mock_validate_event_types.assert_called_once_with()
         mock_run_migrations.assert_called_once()
+        assert "user_preference_service" in app_instance.bot_data
         app_instance.add_error_handler.assert_called_once_with(error_handler)
         app_instance.run_polling.assert_called_once()
         mock_run_webhook.assert_not_called()

--- a/tests/test_user_preferences.py
+++ b/tests/test_user_preferences.py
@@ -1,0 +1,40 @@
+"""Tests for persisted user profile preferences."""
+
+from app.database import Database
+from app.database.migrations import initialize_schema
+from app.services.user_preferences import UserPreferenceService
+
+
+def test_returns_none_when_user_has_no_preferences(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = UserPreferenceService(db)
+
+    assert service.get_timezone(12345) is None
+
+
+def test_saves_and_loads_timezone_preference(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = UserPreferenceService(db)
+
+    service.set_timezone(12345, "Europe/Moscow")
+
+    preference = service.get_timezone(12345)
+    assert preference is not None
+    assert preference.telegram_id == 12345
+    assert preference.timezone == "Europe/Moscow"
+    assert preference.updated_at.tzinfo is not None
+
+
+def test_updates_existing_timezone_preference(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = UserPreferenceService(db)
+
+    service.set_timezone(12345, "Europe/Moscow")
+    service.set_timezone(12345, "Asia/Yekaterinburg")
+
+    preference = service.get_timezone(12345)
+    assert preference is not None
+    assert preference.timezone == "Asia/Yekaterinburg"


### PR DESCRIPTION
## Summary

- Add a persisted user preference service backed by the existing user_preferences table.
- Save timezone selections during booking and reuse them for returning approved users.
- Keep timezone changes available from the duration and availability steps.
- Wire the preference service into runtime bot_data.

## Issue mapping

This is mapped to #53 as prerequisite/base-layer work for profile preferences. It does not implement the reversible displayed-time-window filter acceptance criteria, so #53 remains open.

Roadmap meta-issue #3 remains open and was not modified or closed.

## Validation

- uv run pytest tests/test_user_preferences.py tests/test_booking.py tests/test_main.py -q
- uv run pytest tests/ -q
- uv run ruff check .
- docker build -t telecalbot:profile-preferences-smoke .
- docker run --rm ... import app.main
- docker run --rm ... run_migrations(db)