### PR TITLE
[codex] Add webhook delivery mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -54,7 +54,7 @@ BOOKING_CONVERSATION_REMINDER_SECONDS_BEFORE_TIMEOUT=120
 TELEGRAM_DELIVERY_MODE=polling
 # Required when TELEGRAM_DELIVERY_MODE=webhook.
 TELEGRAM_WEBHOOK_URL=
-# Optional but recommended in production; set as a Fly secret.
+# Required in webhook mode; set as a Fly secret.
 TELEGRAM_WEBHOOK_SECRET_TOKEN=
 TELEGRAM_WEBHOOK_PATH=/telegram/webhook
 TELEGRAM_WEBHOOK_LISTEN=0.0.0.0

--- a/.env.sample
+++ b/.env.sample
@@ -49,6 +49,22 @@ BOOKING_CONVERSATION_TIMEOUT_SECONDS=900
 # Reminder before timeout in seconds (default: 120 = 2 minutes)
 BOOKING_CONVERSATION_REMINDER_SECONDS_BEFORE_TIMEOUT=120
 
+# Telegram Delivery Settings
+# Use polling for local development; Fly sets this to webhook.
+TELEGRAM_DELIVERY_MODE=polling
+# Required when TELEGRAM_DELIVERY_MODE=webhook.
+TELEGRAM_WEBHOOK_URL=
+# Optional but recommended in production; set as a Fly secret.
+TELEGRAM_WEBHOOK_SECRET_TOKEN=
+TELEGRAM_WEBHOOK_PATH=/telegram/webhook
+TELEGRAM_WEBHOOK_LISTEN=0.0.0.0
+TELEGRAM_WEBHOOK_PORT=8080
+TELEGRAM_DROP_PENDING_UPDATES=false
+
+# HTTP Health Settings
+HEALTH_CHECK_PATH=/healthz
+READINESS_CHECK_PATH=/readyz
+
 # Claude Code Configuration (Optional)
 # Returns to project root after every command
 CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=true

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Delivery mode:
 - `TELEGRAM_DELIVERY_MODE=polling` is the default and is intended for local development.
 - `TELEGRAM_DELIVERY_MODE=webhook` starts an HTTP server for Telegram webhooks and health checks.
 - `TELEGRAM_WEBHOOK_URL` is required in webhook mode.
-- `TELEGRAM_WEBHOOK_SECRET_TOKEN` is optional locally and recommended in production.
+- `TELEGRAM_WEBHOOK_SECRET_TOKEN` is required in webhook mode and rejects forged update payloads.
 
 See `.env.sample` for a complete list of configuration options.
 
@@ -87,6 +87,8 @@ Fly runs the bot in webhook mode on port `8080`. The configured production webho
 ```text
 https://telecalbot.fly.dev/telegram/webhook
 ```
+
+Fly currently keeps one machine running because booking conversations and timeout reminders are stored in process memory. Scale-to-zero must remain disabled until that state is persisted.
 
 Set production secrets before deploying:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Cal.com is blocked in some regions (like Russia), preventing users from accessin
 
 4. **Run the bot**
    ```bash
-   # Run instructions coming soon
+   uv run python -m app.main
    ```
 
 ## Configuration
@@ -72,7 +72,52 @@ Required environment variables:
 Optional environment variables:
 - `CALCOM_PRIVACY_EMAIL` - A dedicated deliverable mailbox Cal.com can use when a user chooses not to provide a personal email. If unset or rejected by Cal.com, the bot explains that private booking is temporarily unavailable and offers the user a voluntary email path.
 
+Delivery mode:
+- `TELEGRAM_DELIVERY_MODE=polling` is the default and is intended for local development.
+- `TELEGRAM_DELIVERY_MODE=webhook` starts an HTTP server for Telegram webhooks and health checks.
+- `TELEGRAM_WEBHOOK_URL` is required in webhook mode.
+- `TELEGRAM_WEBHOOK_SECRET_TOKEN` is optional locally and recommended in production.
+
 See `.env.sample` for a complete list of configuration options.
+
+## Deployment
+
+Fly runs the bot in webhook mode on port `8080`. The configured production webhook endpoint is:
+
+```text
+https://telecalbot.fly.dev/telegram/webhook
+```
+
+Set production secrets before deploying:
+
+```bash
+fly secrets set \
+  TELEGRAM_BOT_TOKEN=<telegram-bot-token> \
+  CALCOM_API_KEY=<calcom-api-key> \
+  ADMIN_TELEGRAM_ID=<telegram-admin-id> \
+  TELEGRAM_WEBHOOK_SECRET_TOKEN=<random-secret-token>
+```
+
+Deploy the app:
+
+```bash
+fly deploy --remote-only
+```
+
+After deploy, register the webhook with Telegram. The application also calls `setWebhook` on startup, but this command is useful for explicit verification:
+
+```bash
+curl -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  -d "url=https://telecalbot.fly.dev/telegram/webhook" \
+  -d "secret_token=${TELEGRAM_WEBHOOK_SECRET_TOKEN}"
+```
+
+Check runtime health:
+
+```bash
+curl https://telecalbot.fly.dev/healthz
+curl https://telecalbot.fly.dev/readyz
+```
 
 ## Development Status
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 """Application configuration loaded from environment variables."""
 
 from dataclasses import dataclass
+from typing import Literal
 
 from pydantic_settings import BaseSettings
 
@@ -42,6 +43,19 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     booking_conversation_timeout_seconds: int = 900
     booking_conversation_reminder_seconds_before_timeout: int = 120
+
+    # Telegram Delivery Settings
+    telegram_delivery_mode: Literal["polling", "webhook"] = "polling"
+    telegram_webhook_url: str | None = None
+    telegram_webhook_secret_token: str | None = None
+    telegram_webhook_path: str = "/telegram/webhook"
+    telegram_webhook_listen: str = "0.0.0.0"
+    telegram_webhook_port: int = 8080
+    telegram_drop_pending_updates: bool = False
+
+    # HTTP Health Settings
+    health_check_path: str = "/healthz"
+    readiness_check_path: str = "/readyz"
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 from app.constants import SUPPORTED_BOOKING_DURATIONS
@@ -58,6 +59,14 @@ class Settings(BaseSettings):
     readiness_check_path: str = "/readyz"
 
     model_config = {"env_file": ".env", "extra": "ignore"}
+
+    @field_validator("telegram_webhook_url", "telegram_webhook_secret_token", mode="before")
+    @classmethod
+    def blank_optional_webhook_value_is_unset(cls, value: object) -> object:
+        """Treat blank env values for optional webhook settings as unset."""
+        if isinstance(value, str) and value.strip() == "":
+            return None
+        return value
 
     def resolve_event_type(self, duration_minutes: int) -> ResolvedEventType:
         """Resolve an event type and the duration override Cal.com expects.

--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,9 @@
 """Application configuration loaded from environment variables."""
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 from app.constants import SUPPORTED_BOOKING_DURATIONS
@@ -67,6 +67,17 @@ class Settings(BaseSettings):
         if isinstance(value, str) and value.strip() == "":
             return None
         return value
+
+    @model_validator(mode="after")
+    def webhook_mode_requires_authenticated_endpoint(self) -> Self:
+        """Reject webhook mode unless its public URL and shared secret are configured."""
+        if self.telegram_delivery_mode != "webhook":
+            return self
+        if not self.telegram_webhook_url:
+            raise ValueError("TELEGRAM_WEBHOOK_URL is required in webhook mode")
+        if not self.telegram_webhook_secret_token:
+            raise ValueError("TELEGRAM_WEBHOOK_SECRET_TOKEN is required in webhook mode")
+        return self
 
     def resolve_event_type(self, duration_minutes: int) -> ResolvedEventType:
         """Resolve an event type and the duration override Cal.com expects.

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app.services.booking_service import BookingService
 from app.services.calcom_client import CalComClient
 from app.services.duration_limit import DurationLimitService
 from app.services.whitelist import WhitelistService
+from app.webhook_server import run_webhook
 
 
 def setup_logging() -> None:
@@ -59,20 +60,8 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
     logger.error("Unhandled exception while processing update %r", update, exc_info=error)
 
 
-def main() -> None:
-    """Start the bot."""
-    setup_logging()
-    logger = logging.getLogger(__name__)
-
-    logger.info("Initializing Telecalbot...")
-
-    settings.validate_event_type_configuration()
-
-    # Initialize database
-    run_migrations(db)
-    logger.info(f"Database initialized at {settings.database_path}")
-
-    # Create application
+def create_application() -> Application:
+    """Create and configure the Telegram application."""
     application = Application.builder().token(settings.telegram_bot_token).build()
 
     # Inject services
@@ -133,10 +122,30 @@ def main() -> None:
         )
 
     application.post_init = post_init
+    return application
+
+
+def main() -> None:
+    """Start the bot."""
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
+    logger.info("Initializing Telecalbot...")
+
+    settings.validate_event_type_configuration()
+
+    # Initialize database
+    run_migrations(db)
+    logger.info(f"Database initialized at {settings.database_path}")
+
+    application = create_application()
 
     logger.info("Bot started. Press Ctrl+C to stop.")
 
-    # Start polling
+    if settings.telegram_delivery_mode == "webhook":
+        run_webhook(application, settings)
+        return
+
     application.run_polling()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -140,12 +140,12 @@ def main() -> None:
 
     application = create_application()
 
-    logger.info("Bot started. Press Ctrl+C to stop.")
-
     if settings.telegram_delivery_mode == "webhook":
+        logger.info("Starting Telegram webhook delivery.")
         run_webhook(application, settings)
         return
 
+    logger.info("Starting Telegram polling. Press Ctrl+C to stop.")
     application.run_polling()
 
 

--- a/app/webhook_server.py
+++ b/app/webhook_server.py
@@ -1,0 +1,214 @@
+"""Webhook HTTP server for production Telegram delivery."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import signal
+from http import HTTPStatus
+
+import tornado.web
+from telegram import Update
+from telegram.ext import Application
+from tornado.httpserver import HTTPServer
+
+from app.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_route_path(path: str) -> str:
+    """Return a Tornado route path with one leading slash and no trailing slash."""
+    normalized = f"/{path.strip('/')}"
+    return "/" if normalized == "/" else normalized
+
+
+class HealthHandler(tornado.web.RequestHandler):
+    """Liveness endpoint for Fly HTTP health checks."""
+
+    SUPPORTED_METHODS = ("GET",)  # type: ignore[assignment]
+
+    def get(self) -> None:
+        self.set_status(HTTPStatus.OK)
+        self.write({"status": "ok"})
+
+
+class ReadinessHandler(tornado.web.RequestHandler):
+    """Readiness endpoint that flips after the Telegram application is started."""
+
+    SUPPORTED_METHODS = ("GET",)  # type: ignore[assignment]
+
+    def initialize(self, readiness: asyncio.Event) -> None:
+        self.readiness = readiness
+
+    def get(self) -> None:
+        if self.readiness.is_set():
+            self.set_status(HTTPStatus.OK)
+            self.write({"status": "ready"})
+            return
+
+        self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)
+        self.write({"status": "starting"})
+
+
+class TelegramWebhookHandler(tornado.web.RequestHandler):
+    """Accept Telegram webhook updates and enqueue them for python-telegram-bot."""
+
+    SUPPORTED_METHODS = ("POST",)  # type: ignore[assignment]
+
+    def initialize(
+        self,
+        telegram_application: Application,
+        secret_token: str | None,
+    ) -> None:
+        self.telegram_application = telegram_application
+        self.secret_token = secret_token
+
+    def set_default_headers(self) -> None:
+        self.set_header("Content-Type", "application/json; charset=utf-8")
+
+    async def post(self) -> None:
+        self._validate_request()
+
+        try:
+            payload = json.loads(self.request.body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise tornado.web.HTTPError(
+                HTTPStatus.BAD_REQUEST,
+                reason="Request body is not valid JSON",
+            ) from exc
+
+        update = Update.de_json(payload, self.telegram_application.bot)
+        if update:
+            bot = self.telegram_application.bot
+            if hasattr(bot, "insert_callback_data"):
+                bot.insert_callback_data(update)
+            await self.telegram_application.update_queue.put(update)
+
+        self.set_status(HTTPStatus.OK)
+        self.write({"status": "accepted"})
+
+    def _validate_request(self) -> None:
+        content_type = self.request.headers.get("Content-Type", "")
+        if content_type.split(";", maxsplit=1)[0].strip() != "application/json":
+            raise tornado.web.HTTPError(
+                HTTPStatus.FORBIDDEN,
+                reason="Webhook requests must be JSON",
+            )
+
+        if self.secret_token is None:
+            return
+
+        actual = self.request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+        if actual != self.secret_token:
+            raise tornado.web.HTTPError(
+                HTTPStatus.FORBIDDEN,
+                reason="Webhook secret token is missing or invalid",
+            )
+
+
+def build_webhook_application(
+    *,
+    application: Application,
+    readiness: asyncio.Event,
+    secret_token: str | None,
+    webhook_path: str,
+    health_path: str,
+    readiness_path: str,
+) -> tornado.web.Application:
+    """Build the Tornado application that Fly and Telegram call."""
+    webhook_route = normalize_route_path(webhook_path)
+    health_route = normalize_route_path(health_path)
+    readiness_route = normalize_route_path(readiness_path)
+
+    return tornado.web.Application(
+        [
+            (rf"{health_route}/?", HealthHandler),
+            (rf"{readiness_route}/?", ReadinessHandler, {"readiness": readiness}),
+            (
+                rf"{webhook_route}/?",
+                TelegramWebhookHandler,
+                {"telegram_application": application, "secret_token": secret_token},
+            ),
+        ]
+    )
+
+
+def run_webhook(application: Application, app_settings: Settings) -> None:
+    """Run the Telegram application behind a webhook HTTP server."""
+    asyncio.run(serve_webhook(application, app_settings))
+
+
+async def serve_webhook(application: Application, app_settings: Settings) -> None:
+    """Start Telegram webhook delivery and block until the process is stopped."""
+    if not app_settings.telegram_webhook_url:
+        raise ValueError("TELEGRAM_WEBHOOK_URL is required when TELEGRAM_DELIVERY_MODE=webhook")
+
+    readiness = asyncio.Event()
+    stop_event = asyncio.Event()
+    web_app = build_webhook_application(
+        application=application,
+        readiness=readiness,
+        secret_token=app_settings.telegram_webhook_secret_token,
+        webhook_path=app_settings.telegram_webhook_path,
+        health_path=app_settings.health_check_path,
+        readiness_path=app_settings.readiness_check_path,
+    )
+    server = HTTPServer(web_app)
+    initialized = False
+
+    loop = asyncio.get_running_loop()
+    for signame in ("SIGINT", "SIGTERM"):
+        signum = getattr(signal, signame, None)
+        if signum is None:
+            continue
+        try:
+            loop.add_signal_handler(signum, stop_event.set)
+        except NotImplementedError:
+            pass
+
+    try:
+        await application.initialize()
+        initialized = True
+        if application.post_init:
+            await application.post_init(application)
+
+        await application.bot.set_webhook(
+            url=app_settings.telegram_webhook_url,
+            drop_pending_updates=app_settings.telegram_drop_pending_updates,
+            secret_token=app_settings.telegram_webhook_secret_token,
+        )
+        await application.start()
+        readiness.set()
+
+        server.listen(
+            app_settings.telegram_webhook_port,
+            address=app_settings.telegram_webhook_listen,
+        )
+        logger.info(
+            "Webhook server listening on %s:%s",
+            app_settings.telegram_webhook_listen,
+            app_settings.telegram_webhook_port,
+        )
+        await stop_event.wait()
+    finally:
+        readiness.clear()
+        server.stop()
+        await server.close_all_connections()
+        await _shutdown_application(application, initialized=initialized)
+
+
+async def _shutdown_application(application: Application, *, initialized: bool) -> None:
+    if application.running:
+        await application.stop()
+        if application.post_stop:
+            await application.post_stop(application)
+
+    if not initialized:
+        return
+
+    await application.shutdown()
+    post_shutdown = getattr(application, "post_shutdown", None)
+    if post_shutdown:
+        await post_shutdown(application)

--- a/app/webhook_server.py
+++ b/app/webhook_server.py
@@ -24,6 +24,15 @@ def normalize_route_path(path: str) -> str:
     return "/" if normalized == "/" else normalized
 
 
+def normalize_optional_token(token: str | None) -> str | None:
+    """Return None for blank optional secret-token settings."""
+    if token is None:
+        return None
+    if token.strip() == "":
+        return None
+    return token
+
+
 class HealthHandler(tornado.web.RequestHandler):
     """Liveness endpoint for Fly HTTP health checks."""
 
@@ -73,13 +82,20 @@ class TelegramWebhookHandler(tornado.web.RequestHandler):
 
         try:
             payload = json.loads(self.request.body.decode("utf-8"))
-        except json.JSONDecodeError as exc:
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise tornado.web.HTTPError(
                 HTTPStatus.BAD_REQUEST,
                 reason="Request body is not valid JSON",
             ) from exc
 
-        update = Update.de_json(payload, self.telegram_application.bot)
+        try:
+            update = Update.de_json(payload, self.telegram_application.bot)
+        except Exception as exc:
+            raise tornado.web.HTTPError(
+                HTTPStatus.BAD_REQUEST,
+                reason="Request body is not a valid Telegram update",
+            ) from exc
+
         if update:
             bot = self.telegram_application.bot
             if hasattr(bot, "insert_callback_data"):
@@ -121,6 +137,7 @@ def build_webhook_application(
     webhook_route = normalize_route_path(webhook_path)
     health_route = normalize_route_path(health_path)
     readiness_route = normalize_route_path(readiness_path)
+    normalized_secret_token = normalize_optional_token(secret_token)
 
     return tornado.web.Application(
         [
@@ -129,7 +146,7 @@ def build_webhook_application(
             (
                 rf"{webhook_route}/?",
                 TelegramWebhookHandler,
-                {"telegram_application": application, "secret_token": secret_token},
+                {"telegram_application": application, "secret_token": normalized_secret_token},
             ),
         ]
     )
@@ -145,12 +162,13 @@ async def serve_webhook(application: Application, app_settings: Settings) -> Non
     if not app_settings.telegram_webhook_url:
         raise ValueError("TELEGRAM_WEBHOOK_URL is required when TELEGRAM_DELIVERY_MODE=webhook")
 
+    secret_token = normalize_optional_token(app_settings.telegram_webhook_secret_token)
     readiness = asyncio.Event()
     stop_event = asyncio.Event()
     web_app = build_webhook_application(
         application=application,
         readiness=readiness,
-        secret_token=app_settings.telegram_webhook_secret_token,
+        secret_token=secret_token,
         webhook_path=app_settings.telegram_webhook_path,
         health_path=app_settings.health_check_path,
         readiness_path=app_settings.readiness_check_path,
@@ -177,7 +195,7 @@ async def serve_webhook(application: Application, app_settings: Settings) -> Non
         await application.bot.set_webhook(
             url=app_settings.telegram_webhook_url,
             drop_pending_updates=app_settings.telegram_drop_pending_updates,
-            secret_token=app_settings.telegram_webhook_secret_token,
+            secret_token=secret_token,
         )
         await application.start()
         readiness.set()

--- a/app/webhook_server.py
+++ b/app/webhook_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import signal
@@ -22,15 +23,6 @@ def normalize_route_path(path: str) -> str:
     """Return a Tornado route path with one leading slash and no trailing slash."""
     normalized = f"/{path.strip('/')}"
     return "/" if normalized == "/" else normalized
-
-
-def normalize_optional_token(token: str | None) -> str | None:
-    """Return None for blank optional secret-token settings."""
-    if token is None:
-        return None
-    if token.strip() == "":
-        return None
-    return token
 
 
 class HealthHandler(tornado.web.RequestHandler):
@@ -69,7 +61,7 @@ class TelegramWebhookHandler(tornado.web.RequestHandler):
     def initialize(
         self,
         telegram_application: Application,
-        secret_token: str | None,
+        secret_token: str,
     ) -> None:
         self.telegram_application = telegram_application
         self.secret_token = secret_token
@@ -109,15 +101,12 @@ class TelegramWebhookHandler(tornado.web.RequestHandler):
         content_type = self.request.headers.get("Content-Type", "")
         if content_type.split(";", maxsplit=1)[0].strip() != "application/json":
             raise tornado.web.HTTPError(
-                HTTPStatus.FORBIDDEN,
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
                 reason="Webhook requests must be JSON",
             )
 
-        if self.secret_token is None:
-            return
-
-        actual = self.request.headers.get("X-Telegram-Bot-Api-Secret-Token")
-        if actual != self.secret_token:
+        actual = self.request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+        if not hmac.compare_digest(actual, self.secret_token):
             raise tornado.web.HTTPError(
                 HTTPStatus.FORBIDDEN,
                 reason="Webhook secret token is missing or invalid",
@@ -128,7 +117,7 @@ def build_webhook_application(
     *,
     application: Application,
     readiness: asyncio.Event,
-    secret_token: str | None,
+    secret_token: str,
     webhook_path: str,
     health_path: str,
     readiness_path: str,
@@ -137,8 +126,6 @@ def build_webhook_application(
     webhook_route = normalize_route_path(webhook_path)
     health_route = normalize_route_path(health_path)
     readiness_route = normalize_route_path(readiness_path)
-    normalized_secret_token = normalize_optional_token(secret_token)
-
     return tornado.web.Application(
         [
             (rf"{health_route}/?", HealthHandler),
@@ -146,7 +133,7 @@ def build_webhook_application(
             (
                 rf"{webhook_route}/?",
                 TelegramWebhookHandler,
-                {"telegram_application": application, "secret_token": normalized_secret_token},
+                {"telegram_application": application, "secret_token": secret_token},
             ),
         ]
     )
@@ -157,14 +144,23 @@ def run_webhook(application: Application, app_settings: Settings) -> None:
     asyncio.run(serve_webhook(application, app_settings))
 
 
-async def serve_webhook(application: Application, app_settings: Settings) -> None:
+async def serve_webhook(
+    application: Application,
+    app_settings: Settings,
+    *,
+    stop_event: asyncio.Event | None = None,
+) -> None:
     """Start Telegram webhook delivery and block until the process is stopped."""
     if not app_settings.telegram_webhook_url:
         raise ValueError("TELEGRAM_WEBHOOK_URL is required when TELEGRAM_DELIVERY_MODE=webhook")
+    if not app_settings.telegram_webhook_secret_token:
+        raise ValueError(
+            "TELEGRAM_WEBHOOK_SECRET_TOKEN is required when TELEGRAM_DELIVERY_MODE=webhook"
+        )
 
-    secret_token = normalize_optional_token(app_settings.telegram_webhook_secret_token)
+    secret_token = app_settings.telegram_webhook_secret_token
     readiness = asyncio.Event()
-    stop_event = asyncio.Event()
+    configured_stop_event = stop_event or asyncio.Event()
     web_app = build_webhook_application(
         application=application,
         readiness=readiness,
@@ -175,18 +171,30 @@ async def serve_webhook(application: Application, app_settings: Settings) -> Non
     )
     server = HTTPServer(web_app)
     initialized = False
+    started = False
 
-    loop = asyncio.get_running_loop()
-    for signame in ("SIGINT", "SIGTERM"):
-        signum = getattr(signal, signame, None)
-        if signum is None:
-            continue
-        try:
-            loop.add_signal_handler(signum, stop_event.set)
-        except NotImplementedError:
-            pass
+    if stop_event is None:
+        loop = asyncio.get_running_loop()
+        for signame in ("SIGINT", "SIGTERM"):
+            signum = getattr(signal, signame, None)
+            if signum is None:
+                continue
+            try:
+                loop.add_signal_handler(signum, configured_stop_event.set)
+            except NotImplementedError:
+                pass
 
     try:
+        server.listen(
+            app_settings.telegram_webhook_port,
+            address=app_settings.telegram_webhook_listen,
+        )
+        logger.info(
+            "Webhook server listening on %s:%s",
+            app_settings.telegram_webhook_listen,
+            app_settings.telegram_webhook_port,
+        )
+
         await application.initialize()
         initialized = True
         if application.post_init:
@@ -198,27 +206,24 @@ async def serve_webhook(application: Application, app_settings: Settings) -> Non
             secret_token=secret_token,
         )
         await application.start()
+        started = True
         readiness.set()
-
-        server.listen(
-            app_settings.telegram_webhook_port,
-            address=app_settings.telegram_webhook_listen,
-        )
-        logger.info(
-            "Webhook server listening on %s:%s",
-            app_settings.telegram_webhook_listen,
-            app_settings.telegram_webhook_port,
-        )
-        await stop_event.wait()
+        logger.info("Telegram webhook delivery is ready")
+        await configured_stop_event.wait()
     finally:
         readiness.clear()
         server.stop()
         await server.close_all_connections()
-        await _shutdown_application(application, initialized=initialized)
+        await _shutdown_application(application, initialized=initialized, started=started)
 
 
-async def _shutdown_application(application: Application, *, initialized: bool) -> None:
-    if application.running:
+async def _shutdown_application(
+    application: Application,
+    *,
+    initialized: bool,
+    started: bool,
+) -> None:
+    if started:
         await application.stop()
         if application.post_stop:
             await application.post_stop(application)

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,13 @@ primary_region = 'fra'
 
 [env]
 DATABASE_PATH = "/data/telecalbot.db"
+TELEGRAM_DELIVERY_MODE = "webhook"
+TELEGRAM_WEBHOOK_URL = "https://telecalbot.fly.dev/telegram/webhook"
+TELEGRAM_WEBHOOK_PATH = "/telegram/webhook"
+TELEGRAM_WEBHOOK_LISTEN = "0.0.0.0"
+TELEGRAM_WEBHOOK_PORT = "8080"
+HEALTH_CHECK_PATH = "/healthz"
+READINESS_CHECK_PATH = "/readyz"
 
 [processes]
 app = "/app/.venv/bin/python -m app.main"
@@ -15,10 +22,17 @@ app = "/app/.venv/bin/python -m app.main"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'off'
+  auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ['app']
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/healthz"
 
 [[mounts]]
   source = "telecalbot_data"

--- a/fly.toml
+++ b/fly.toml
@@ -22,9 +22,9 @@ app = "/app/.venv/bin/python -m app.main"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
   [[http_service.checks]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Telegram bot for booking Cal.com appointments"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "python-telegram-bot[job-queue]>=20.0",
+    "python-telegram-bot[job-queue,webhooks]>=20.0",
     "httpx>=0.25.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,8 +1,10 @@
 """Tests for GitHub Actions workflow safety invariants."""
 
+import tomllib
 from pathlib import Path
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "test.yml"
+FLY_CONFIG = Path(__file__).resolve().parents[1] / "fly.toml"
 
 
 def test_deploy_uses_pinned_flyctl_install():
@@ -12,3 +14,15 @@ def test_deploy_uses_pinned_flyctl_install():
     assert "FLYCTL_VERSION:" in workflow
     assert "FLYCTL_SHA256:" in workflow
     assert "sha256sum --check flyctl.sha256" in workflow
+
+
+def test_fly_uses_webhook_http_delivery():
+    config = tomllib.loads(FLY_CONFIG.read_text())
+
+    assert config["env"]["TELEGRAM_DELIVERY_MODE"] == "webhook"
+    assert config["env"]["TELEGRAM_WEBHOOK_PATH"] == "/telegram/webhook"
+    assert config["http_service"]["internal_port"] == 8080
+    assert config["http_service"]["auto_stop_machines"] == "stop"
+    assert config["http_service"]["auto_start_machines"] is True
+    assert config["http_service"]["min_machines_running"] == 0
+    assert config["http_service"]["checks"][0]["path"] == "/healthz"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -22,7 +22,7 @@ def test_fly_uses_webhook_http_delivery():
     assert config["env"]["TELEGRAM_DELIVERY_MODE"] == "webhook"
     assert config["env"]["TELEGRAM_WEBHOOK_PATH"] == "/telegram/webhook"
     assert config["http_service"]["internal_port"] == 8080
-    assert config["http_service"]["auto_stop_machines"] == "stop"
+    assert config["http_service"]["auto_stop_machines"] == "off"
     assert config["http_service"]["auto_start_machines"] is True
-    assert config["http_service"]["min_machines_running"] == 0
+    assert config["http_service"]["min_machines_running"] == 1
     assert config["http_service"]["checks"][0]["path"] == "/healthz"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,32 @@ def test_blank_optional_webhook_settings_are_unset():
     assert settings.telegram_webhook_secret_token is None
 
 
+@pytest.mark.parametrize(
+    ("overrides", "missing_setting"),
+    [
+        ({"telegram_webhook_secret_token": "secret"}, "TELEGRAM_WEBHOOK_URL"),
+        ({"telegram_webhook_url": "https://example.com/webhook"}, "TELEGRAM_WEBHOOK_SECRET_TOKEN"),
+    ],
+)
+def test_webhook_mode_requires_url_and_secret(overrides, missing_setting):
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match=missing_setting):
+        Settings(telegram_delivery_mode="webhook", **overrides)
+
+
+def test_webhook_mode_accepts_authenticated_configuration():
+    from app.config import Settings
+
+    settings = Settings(
+        telegram_delivery_mode="webhook",
+        telegram_webhook_url="https://example.com/webhook",
+        telegram_webhook_secret_token="secret",
+    )
+
+    assert settings.telegram_delivery_mode == "webhook"
+
+
 def test_get_event_type_id_with_duration_specific():
     """Test get_event_type_id returns duration-specific IDs."""
     from app.config import Settings

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,13 @@ def test_config_defaults():
     assert settings.booking_conversation_timeout_seconds == 900
     assert settings.booking_conversation_reminder_seconds_before_timeout == 120
     assert settings.calcom_privacy_email is None
+    assert settings.telegram_delivery_mode == "polling"
+    assert settings.telegram_webhook_url is None
+    assert settings.telegram_webhook_path == "/telegram/webhook"
+    assert settings.telegram_webhook_listen == "0.0.0.0"
+    assert settings.telegram_webhook_port == 8080
+    assert settings.health_check_path == "/healthz"
+    assert settings.readiness_check_path == "/readyz"
 
 
 def test_config_accepts_privacy_email():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,19 @@ def test_config_accepts_privacy_email():
     assert settings.calcom_privacy_email == "private-bookings@example.net"
 
 
+def test_blank_optional_webhook_settings_are_unset():
+    """Test that blank optional webhook values behave like unset values."""
+    from app.config import Settings
+
+    settings = Settings(
+        telegram_webhook_url="",
+        telegram_webhook_secret_token="",
+    )
+
+    assert settings.telegram_webhook_url is None
+    assert settings.telegram_webhook_secret_token is None
+
+
 def test_get_event_type_id_with_duration_specific():
     """Test get_event_type_id returns duration-specific IDs."""
     from app.config import Settings

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from telegram.error import NetworkError
 
-from app.main import error_handler, main
+from app.main import error_handler, main, settings
 
 
 class TestErrorHandler:
@@ -58,6 +58,7 @@ class TestMain:
         mock_run_migrations.assert_not_called()
 
     @patch("app.config.Settings.validate_event_type_configuration")
+    @patch("app.main.run_webhook")
     @patch("app.main.Application")
     @patch("app.main.run_migrations")
     @patch("app.main.setup_logging")
@@ -66,8 +67,11 @@ class TestMain:
         mock_setup_logging,
         mock_run_migrations,
         mock_application,
+        mock_run_webhook,
         mock_validate_event_types,
+        monkeypatch,
     ):
+        monkeypatch.setattr("app.main.settings.telegram_delivery_mode", "polling")
         app_instance = MagicMock()
         mock_application.builder.return_value.token.return_value.build.return_value = app_instance
 
@@ -78,3 +82,31 @@ class TestMain:
         mock_run_migrations.assert_called_once()
         app_instance.add_error_handler.assert_called_once_with(error_handler)
         app_instance.run_polling.assert_called_once()
+        mock_run_webhook.assert_not_called()
+
+    @patch("app.main.run_webhook")
+    @patch("app.config.Settings.validate_event_type_configuration")
+    @patch("app.main.Application")
+    @patch("app.main.run_migrations")
+    @patch("app.main.setup_logging")
+    def test_starts_webhook_when_configured(
+        self,
+        mock_setup_logging,
+        mock_run_migrations,
+        mock_application,
+        mock_validate_event_types,
+        mock_run_webhook,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.main.settings.telegram_delivery_mode", "webhook")
+        app_instance = MagicMock()
+        mock_application.builder.return_value.token.return_value.build.return_value = app_instance
+
+        main()
+
+        mock_setup_logging.assert_called_once()
+        mock_validate_event_types.assert_called_once_with()
+        mock_run_migrations.assert_called_once()
+        app_instance.add_error_handler.assert_called_once_with(error_handler)
+        app_instance.run_polling.assert_not_called()
+        mock_run_webhook.assert_called_once_with(app_instance, settings)

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -89,3 +89,54 @@ async def test_webhook_requires_secret_and_enqueues_update():
     assert accepted.status_code == 200
     assert accepted.json() == {"status": "accepted"}
     assert update.update_id == 123
+
+
+@pytest.mark.asyncio
+async def test_blank_webhook_secret_is_treated_as_unset():
+    update_queue = asyncio.Queue()
+    application = SimpleNamespace(bot=MagicMock(), update_queue=update_queue)
+    web_app = build_webhook_application(
+        application=application,
+        readiness=asyncio.Event(),
+        secret_token="",
+        webhook_path="/telegram/webhook",
+        health_path="/healthz",
+        readiness_path="/readyz",
+    )
+
+    async with LocalServer(web_app) as base_url:
+        async with httpx.AsyncClient() as client:
+            accepted = await client.post(
+                f"{base_url}/telegram/webhook",
+                json={"update_id": 456},
+            )
+
+    update = update_queue.get_nowait()
+
+    assert accepted.status_code == 200
+    assert accepted.json() == {"status": "accepted"}
+    assert update.update_id == 456
+
+
+@pytest.mark.asyncio
+async def test_malformed_telegram_update_returns_bad_request():
+    update_queue = asyncio.Queue()
+    application = SimpleNamespace(bot=MagicMock(), update_queue=update_queue)
+    web_app = build_webhook_application(
+        application=application,
+        readiness=asyncio.Event(),
+        secret_token=None,
+        webhook_path="/telegram/webhook",
+        health_path="/healthz",
+        readiness_path="/readyz",
+    )
+
+    async with LocalServer(web_app) as base_url:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{base_url}/telegram/webhook",
+                json={"message": {}},
+            )
+
+    assert response.status_code == 400
+    assert update_queue.empty()

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,0 +1,91 @@
+"""Tests for the production webhook HTTP surface."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from tornado.httpserver import HTTPServer
+from tornado.netutil import bind_sockets
+
+from app.webhook_server import build_webhook_application
+
+
+class LocalServer:
+    """Context manager for a local Tornado test server."""
+
+    def __init__(self, app):
+        self.app = app
+        self.server = HTTPServer(app)
+        self.sockets = bind_sockets(0, address="127.0.0.1")
+        self.port = self.sockets[0].getsockname()[1]
+
+    async def __aenter__(self):
+        self.server.add_sockets(self.sockets)
+        return f"http://127.0.0.1:{self.port}"
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.server.stop()
+        await self.server.close_all_connections()
+
+
+@pytest.mark.asyncio
+async def test_health_is_available_before_readiness():
+    readiness = asyncio.Event()
+    web_app = build_webhook_application(
+        application=SimpleNamespace(bot=MagicMock(), update_queue=asyncio.Queue()),
+        readiness=readiness,
+        secret_token=None,
+        webhook_path="/telegram/webhook",
+        health_path="/healthz",
+        readiness_path="/readyz",
+    )
+
+    async with LocalServer(web_app) as base_url:
+        async with httpx.AsyncClient() as client:
+            health = await client.get(f"{base_url}/healthz")
+            starting = await client.get(f"{base_url}/readyz")
+
+            readiness.set()
+            ready = await client.get(f"{base_url}/readyz")
+
+    assert health.status_code == 200
+    assert health.json() == {"status": "ok"}
+    assert starting.status_code == 503
+    assert starting.json() == {"status": "starting"}
+    assert ready.status_code == 200
+    assert ready.json() == {"status": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_webhook_requires_secret_and_enqueues_update():
+    update_queue = asyncio.Queue()
+    application = SimpleNamespace(bot=MagicMock(), update_queue=update_queue)
+    web_app = build_webhook_application(
+        application=application,
+        readiness=asyncio.Event(),
+        secret_token="test-secret",
+        webhook_path="/telegram/webhook",
+        health_path="/healthz",
+        readiness_path="/readyz",
+    )
+
+    async with LocalServer(web_app) as base_url:
+        async with httpx.AsyncClient() as client:
+            forbidden = await client.post(
+                f"{base_url}/telegram/webhook",
+                json={"update_id": 123},
+            )
+            accepted = await client.post(
+                f"{base_url}/telegram/webhook",
+                json={"update_id": 123},
+                headers={"X-Telegram-Bot-Api-Secret-Token": "test-secret"},
+            )
+
+    update = update_queue.get_nowait()
+
+    assert forbidden.status_code == 403
+    assert accepted.status_code == 200
+    assert accepted.json() == {"status": "accepted"}
+    assert update.update_id == 123

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -2,14 +2,15 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from tornado.httpserver import HTTPServer
 from tornado.netutil import bind_sockets
 
-from app.webhook_server import build_webhook_application
+from app.config import Settings
+from app.webhook_server import build_webhook_application, serve_webhook
 
 
 class LocalServer:
@@ -36,7 +37,7 @@ async def test_health_is_available_before_readiness():
     web_app = build_webhook_application(
         application=SimpleNamespace(bot=MagicMock(), update_queue=asyncio.Queue()),
         readiness=readiness,
-        secret_token=None,
+        secret_token="test-secret",
         webhook_path="/telegram/webhook",
         health_path="/healthz",
         readiness_path="/readyz",
@@ -92,13 +93,11 @@ async def test_webhook_requires_secret_and_enqueues_update():
 
 
 @pytest.mark.asyncio
-async def test_blank_webhook_secret_is_treated_as_unset():
-    update_queue = asyncio.Queue()
-    application = SimpleNamespace(bot=MagicMock(), update_queue=update_queue)
+async def test_non_json_webhook_request_returns_unsupported_media_type():
     web_app = build_webhook_application(
-        application=application,
+        application=SimpleNamespace(bot=MagicMock(), update_queue=asyncio.Queue()),
         readiness=asyncio.Event(),
-        secret_token="",
+        secret_token="test-secret",
         webhook_path="/telegram/webhook",
         health_path="/healthz",
         readiness_path="/readyz",
@@ -106,16 +105,16 @@ async def test_blank_webhook_secret_is_treated_as_unset():
 
     async with LocalServer(web_app) as base_url:
         async with httpx.AsyncClient() as client:
-            accepted = await client.post(
+            response = await client.post(
                 f"{base_url}/telegram/webhook",
-                json={"update_id": 456},
+                content="{}",
+                headers={
+                    "Content-Type": "text/plain",
+                    "X-Telegram-Bot-Api-Secret-Token": "test-secret",
+                },
             )
 
-    update = update_queue.get_nowait()
-
-    assert accepted.status_code == 200
-    assert accepted.json() == {"status": "accepted"}
-    assert update.update_id == 456
+    assert response.status_code == 415
 
 
 @pytest.mark.asyncio
@@ -125,7 +124,7 @@ async def test_malformed_telegram_update_returns_bad_request():
     web_app = build_webhook_application(
         application=application,
         readiness=asyncio.Event(),
-        secret_token=None,
+        secret_token="test-secret",
         webhook_path="/telegram/webhook",
         health_path="/healthz",
         readiness_path="/readyz",
@@ -136,7 +135,44 @@ async def test_malformed_telegram_update_returns_bad_request():
             response = await client.post(
                 f"{base_url}/telegram/webhook",
                 json={"message": {}},
+                headers={"X-Telegram-Bot-Api-Secret-Token": "test-secret"},
             )
 
     assert response.status_code == 400
     assert update_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_webhook_listener_starts_before_telegram_initialization():
+    events = []
+    application = MagicMock()
+    application.initialize = AsyncMock(side_effect=lambda: events.append("initialize"))
+    application.post_init = AsyncMock(side_effect=lambda app: events.append("post_init"))
+    application.bot.set_webhook = AsyncMock(side_effect=lambda **kwargs: events.append("set_webhook"))
+    application.start = AsyncMock(side_effect=lambda: events.append("start"))
+    application.running = True
+    application.stop = AsyncMock()
+    application.post_stop = None
+    application.shutdown = AsyncMock()
+    application.post_shutdown = None
+
+    server = MagicMock()
+    server.listen.side_effect = lambda *args, **kwargs: events.append("listen")
+    server.close_all_connections = AsyncMock()
+    stop_event = asyncio.Event()
+    stop_event.set()
+    settings = Settings(
+        telegram_delivery_mode="webhook",
+        telegram_webhook_url="https://example.com/telegram/webhook",
+        telegram_webhook_secret_token="test-secret",
+    )
+
+    with patch("app.webhook_server.HTTPServer", return_value=server):
+        await serve_webhook(application, settings, stop_event=stop_event)
+
+    assert events[:5] == ["listen", "initialize", "post_init", "set_webhook", "start"]
+    application.bot.set_webhook.assert_awaited_once_with(
+        url="https://example.com/telegram/webhook",
+        drop_pending_updates=False,
+        secret_token="test-secret",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -316,6 +316,9 @@ wheels = [
 job-queue = [
     { name = "apscheduler" },
 ]
+webhooks = [
+    { name = "tornado" },
+]
 
 [[package]]
 name = "ruff"
@@ -351,7 +354,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "python-telegram-bot", extra = ["job-queue"] },
+    { name = "python-telegram-bot", extra = ["job-queue", "webhooks"] },
 ]
 
 [package.dev-dependencies]
@@ -366,7 +369,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "python-telegram-bot", extras = ["job-queue"], specifier = ">=20.0" },
+    { name = "python-telegram-bot", extras = ["job-queue", "webhooks"], specifier = ">=20.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -374,6 +377,23 @@ dev = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add configurable polling/webhook startup mode with a Tornado webhook server
- expose authenticated Telegram webhook, health, and readiness routes
- bind liveness before Telegram initialization and keep readiness closed until startup completes
- align Fly with webhook HTTP delivery while keeping one machine running for in-memory conversations and reminders
- document local polling plus Fly webhook deployment steps

## Review feedback addressed
- rebased onto current main and preserved startup event-type validation
- require both TELEGRAM_WEBHOOK_URL and TELEGRAM_WEBHOOK_SECRET_TOKEN in webhook mode
- compare webhook secrets in constant time and return 415 for unsupported media types
- add lifecycle coverage for listener/startup ordering
- keep scale-to-zero disabled until conversation and JobQueue state are persisted

Closes #46

## Validation
- uv sync --frozen
- uv run ruff check .
- uv run pytest tests/ -v (254 passed)
- docker build -t telecalbot:webhook-review .
- Docker application import smoke (import-ok)
- Docker database migration smoke (migrations-ok)
- fly.toml is parsed and asserted by tests/test_ci_workflow.py

flyctl config validate could not run because this environment has no Fly access token.