### PR TITLE
[codex] Enforce duration limits at booking time

### DIFF
--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -123,6 +123,36 @@ def _is_whitelisted(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     return whitelist_service.is_whitelisted(user_id)
 
 
+def _get_duration_limit(
+    context: ContextTypes.DEFAULT_TYPE,
+    user_id: int,
+) -> int | None:
+    duration_limit_service: DurationLimitService | None = context.bot_data.get(
+        "duration_limit_service"
+    )
+    if duration_limit_service is None:
+        return None
+    return duration_limit_service.get_limit(user_id)
+
+
+def _apply_current_duration_limit(
+    context: ContextTypes.DEFAULT_TYPE,
+    user_id: int,
+    requested_duration: int,
+) -> int:
+    max_duration = _get_duration_limit(context, user_id)
+    if max_duration is None or requested_duration <= max_duration:
+        return requested_duration
+
+    logger.info(
+        "Capping booking duration for user_id=%s from %s to %s minutes",
+        user_id,
+        requested_duration,
+        max_duration,
+    )
+    return max_duration
+
+
 def _booking_reminder_job_name(user_id: int) -> str:
     return f"{BOOKING_REMINDER_JOB_PREFIX}{user_id}"
 
@@ -260,13 +290,7 @@ async def _handle_duration_selection(query, context: ContextTypes.DEFAULT_TYPE) 
     """Check duration limits and show duration picker or auto-select."""
     user_id = query.from_user.id
     _refresh_booking_timeout_reminder(context, user_id)
-    duration_limit_service: DurationLimitService | None = context.bot_data.get(
-        "duration_limit_service"
-    )
-
-    max_duration = None
-    if duration_limit_service:
-        max_duration = duration_limit_service.get_limit(user_id)
+    max_duration = _get_duration_limit(context, user_id)
 
     if max_duration is not None:
         # User has a limit — auto-select that duration, skip picker
@@ -296,6 +320,7 @@ async def select_duration(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if duration not in DURATION_OPTIONS:
         return BookingState.SELECTING_DURATION
 
+    duration = _apply_current_duration_limit(context, query.from_user.id, duration)
     context.user_data["duration"] = duration
     _refresh_booking_timeout_reminder(context, query.from_user.id)
 
@@ -331,7 +356,12 @@ async def _show_availability(
 
     calcom_client: CalComClient = context.bot_data["calcom_client"]
     timezone_id = context.user_data["timezone"]
-    duration = context.user_data.get("duration", 30)
+    duration = _apply_current_duration_limit(
+        context,
+        query.from_user.id,
+        context.user_data.get("duration", 30),
+    )
+    context.user_data["duration"] = duration
     event_type_id = settings.get_event_type_id(duration)
     today = date.today()
 
@@ -566,7 +596,12 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     data = context.user_data
     calcom_client: CalComClient = context.bot_data["calcom_client"]
     email = data.get("email") or f"telegram-{update.effective_user.id}@telecalbot.local"
-    duration = data.get("duration", 30)
+    duration = _apply_current_duration_limit(
+        context,
+        update.effective_user.id,
+        data.get("duration", 30),
+    )
+    data["duration"] = duration
     event_type_id = settings.get_event_type_id(duration)
 
     try:

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -730,6 +730,30 @@ class TestConfirmBooking:
         assert "telegram_user_id" in request.metadata
 
     @pytest.mark.asyncio
+    async def test_applies_current_duration_limit_when_confirming(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        booking_response,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {**user_data_ready, "duration": 60}
+        mock_calcom_client.create_booking.return_value = booking_response
+        duration_limit_service = MagicMock()
+        duration_limit_service.get_limit.return_value = 30
+        mock_context.bot_data["duration_limit_service"] = duration_limit_service
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            await confirm_booking(mock_update_with_query, mock_context)
+
+        mock_settings.get_event_type_id.assert_called_once_with(30)
+        request = mock_calcom_client.create_booking.call_args[0][0]
+        assert request.eventTypeId == 30
+
+    @pytest.mark.asyncio
     async def test_returns_conversation_end_on_success(
         self,
         mock_update_with_query,

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -65,6 +65,28 @@ class TestDurationSelection:
         assert mock_context.user_data["duration"] == 60
 
     @pytest.mark.asyncio
+    async def test_select_duration_caps_stale_callback_for_limited_user(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "duration:60"
+        mock_calcom = AsyncMock()
+        mock_calcom.get_availability = AsyncMock(return_value=MagicMock(slots={}))
+        mock_duration_service = MagicMock(spec=DurationLimitService)
+        mock_duration_service.get_limit.return_value = 30
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom,
+            "duration_limit_service": mock_duration_service,
+        }
+        mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            await select_duration(mock_update_with_query, mock_context)
+
+        assert mock_context.user_data["duration"] == 30
+        mock_settings.get_event_type_id.assert_called_once_with(30)
+
+    @pytest.mark.asyncio
     async def test_select_duration_proceeds_to_availability(self, mock_update_with_query, mock_context):
         mock_update_with_query.callback_query.data = "duration:30"
         mock_calcom = AsyncMock()


### PR DESCRIPTION
## Summary

- Re-check the current per-user duration limit before showing availability and before creating a Cal.com booking.
- Cap stale or previously selected 60-minute duration state down to the current limit, so a user limited to 30 minutes cannot book a one-hour session.
- Add regressions for stale `duration:60` callbacks and final confirmation with stale 60-minute `user_data`.

## Root Cause

Duration limits were only applied when the normal timezone-selection flow reached duration handling. Later steps trusted the existing `context.user_data["duration"]`, so a stale callback or already-started booking flow could keep using 60 minutes after a 30-minute limit was set.

## Validation

- `uv run pytest tests/test_booking.py::TestConfirmBooking::test_applies_current_duration_limit_when_confirming tests/test_booking_duration.py::TestDurationSelection::test_select_duration_caps_stale_callback_for_limited_user -q`
- `uv run pytest tests/test_booking.py tests/test_booking_duration.py tests/test_duration_limit.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check .`

Issue #3 remains open and was not modified.
