### PR TITLE
One-time duration limits (silent), consumed on booking

### DIFF
--- a/app/database/migrations.py
+++ b/app/database/migrations.py
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS duration_limits (
     telegram_id INTEGER PRIMARY KEY,
     max_duration_minutes INTEGER NOT NULL,
     set_at TEXT NOT NULL,
-    set_by INTEGER NOT NULL
+    set_by INTEGER NOT NULL,
+    one_time INTEGER NOT NULL DEFAULT 0
 );
 
 -- Persisted bookings for /cancel_booking flow
@@ -72,6 +73,25 @@ def run_migrations(db: Database) -> None:
     initialize_schema(db)
     _migrate_bookings_time_columns(db)
     _ensure_bookings_indexes(db)
+    _ensure_duration_limit_scope(db)
+
+
+def _ensure_duration_limit_scope(db: Database) -> None:
+    """Add the one_time scope column to duration_limits for existing databases."""
+    table_exists = db.execute_one(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='duration_limits'"
+    )
+    if table_exists is None:
+        return
+
+    columns = {row["name"] for row in db.execute("PRAGMA table_info(duration_limits)")}
+    if "one_time" in columns:
+        return
+
+    logger.info("Adding one_time column to duration_limits")
+    db.execute_write(
+        "ALTER TABLE duration_limits ADD COLUMN one_time INTEGER NOT NULL DEFAULT 0"
+    )
 
 
 def _migrate_bookings_time_columns(db: Database) -> None:

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -651,14 +651,20 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         duration_limit_service: DurationLimitService | None = context.bot_data.get(
             "duration_limit_service"
         )
-        if (
-            duration_limit_service is not None
-            and duration_limit_service.consume_one_time_limit(update.effective_user.id)
-        ):
-            logger.info(
-                "Cleared one-time duration limit for user_id=%s after booking",
-                update.effective_user.id,
-            )
+        if duration_limit_service is not None:
+            # Booking already succeeded — never let cleanup failure surface as an
+            # error to the user, or they may retry and double-book.
+            try:
+                if duration_limit_service.consume_one_time_limit(update.effective_user.id):
+                    logger.info(
+                        "Cleared one-time duration limit for user_id=%s after booking",
+                        update.effective_user.id,
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to clear one-time duration limit for user_id=%s after booking",
+                    update.effective_user.id,
+                )
 
         formatted_time = _format_datetime_display(
             data["selected_date"],

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -648,6 +648,18 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             booking.status,
         )
 
+        duration_limit_service: DurationLimitService | None = context.bot_data.get(
+            "duration_limit_service"
+        )
+        if (
+            duration_limit_service is not None
+            and duration_limit_service.consume_one_time_limit(update.effective_user.id)
+        ):
+            logger.info(
+                "Cleared one-time duration limit for user_id=%s after booking",
+                update.effective_user.id,
+            )
+
         formatted_time = _format_datetime_display(
             data["selected_date"],
             data["selected_time"],

--- a/app/handlers/duration_limit.py
+++ b/app/handlers/duration_limit.py
@@ -12,14 +12,37 @@ logger = logging.getLogger(__name__)
 
 VALID_DURATIONS = (30, 60)
 
+# Optional trailing keyword on /setlimit choosing how long the limit lasts.
+# With no keyword the limit is one-time: it applies to the next booking only
+# and clears itself afterwards.
+ONGOING_KEYWORDS = {"постоянно", "навсегда", "always", "ongoing", "permanent"}
+ONE_TIME_KEYWORDS = {"разово", "разовый", "once", "onetime"}
+
+
+def _parse_scope(args: list[str]) -> tuple[list[str], bool]:
+    """Strip an optional trailing scope keyword.
+
+    Returns the remaining args and whether the limit is one-time (default True).
+    """
+    if args:
+        token = args[-1].lower()
+        if token in ONGOING_KEYWORDS:
+            return args[:-1], False
+        if token in ONE_TIME_KEYWORDS:
+            return args[:-1], True
+    return list(args), True
+
 
 @admin_only
 async def setlimit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
     Handle /setlimit command to set a duration limit for a user.
 
-    Usage: /setlimit <telegram_id> <minutes>
-    Or reply to a user's message: /setlimit <minutes>
+    Usage: /setlimit <telegram_id> <minutes> [постоянно]
+    Or reply to a user's message: /setlimit <minutes> [постоянно]
+
+    Without a trailing keyword the limit is one-time (applies to the next
+    booking only). Add "постоянно" to make it ongoing until removed.
     """
     duration_limit_service: DurationLimitService = context.bot_data["duration_limit_service"]
 
@@ -30,28 +53,30 @@ async def setlimit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         else None
     )
 
+    args, one_time = _parse_scope(context.args or [])
+
     if reply_target:
         # /setlimit <minutes> (as reply)
-        if not context.args:
+        if not args:
             await update.message.reply_text("Использование: /setlimit <минуты> (в ответ на сообщение)")
             return
         try:
-            minutes = int(context.args[0])
+            minutes = int(args[0])
         except ValueError:
             await update.message.reply_text("Минуты должны быть числом.")
             return
         telegram_id = reply_target
     else:
         # /setlimit <telegram_id> <minutes>
-        if not context.args or len(context.args) < 2:
+        if len(args) < 2:
             await update.message.reply_text(
                 "Использование: /setlimit <telegram_id> <минуты>\n"
                 "Или ответьте на сообщение: /setlimit <минуты>"
             )
             return
         try:
-            telegram_id = int(context.args[0])
-            minutes = int(context.args[1])
+            telegram_id = int(args[0])
+            minutes = int(args[1])
         except ValueError:
             await update.message.reply_text("Telegram ID и минуты должны быть числами.")
             return
@@ -66,17 +91,21 @@ async def setlimit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         telegram_id=telegram_id,
         max_duration_minutes=minutes,
         set_by=update.effective_user.id,
+        one_time=one_time,
     )
 
     logger.info(
-        "Admin %s set duration limit %d min for user %s",
+        "Admin %s set duration limit %d min (%s) for user %s",
         update.effective_user.id,
         minutes,
+        "one-time" if one_time else "ongoing",
         telegram_id,
     )
 
+    scope_label = "разовый (на одну запись)" if one_time else "постоянный"
     await update.message.reply_text(
-        f"Лимит установлен: пользователь {telegram_id} — максимум {minutes} мин."
+        f"Лимит установлен: пользователь {telegram_id} — максимум {minutes} мин. "
+        f"— {scope_label}."
     )
 
 
@@ -141,8 +170,10 @@ async def limits_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
     lines = ["Установленные лимиты:\n"]
     for limit in limits:
+        scope_label = "разовый" if limit.get("one_time") else "постоянный"
         lines.append(
-            f"• ID {limit['telegram_id']} — макс. {limit['max_duration_minutes']} мин."
+            f"• ID {limit['telegram_id']} — макс. {limit['max_duration_minutes']} мин. "
+            f"({scope_label})"
         )
 
     await update.message.reply_text("\n".join(lines))

--- a/app/services/duration_limit.py
+++ b/app/services/duration_limit.py
@@ -22,20 +22,31 @@ class DurationLimitService:
         return row["max_duration_minutes"]
 
     def set_limit(
-        self, telegram_id: int, max_duration_minutes: int, set_by: int
+        self,
+        telegram_id: int,
+        max_duration_minutes: int,
+        set_by: int,
+        one_time: bool = True,
     ) -> None:
-        """Set or update a duration limit for a user."""
+        """Set or update a duration limit for a user.
+
+        A one-time limit applies to the user's next successful booking and is
+        cleared automatically afterwards. An ongoing limit (one_time=False)
+        persists until an admin removes it.
+        """
         now = datetime.now(timezone.utc).isoformat()
         self.db.execute_write(
             """
-            INSERT INTO duration_limits (telegram_id, max_duration_minutes, set_at, set_by)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO duration_limits
+                (telegram_id, max_duration_minutes, set_at, set_by, one_time)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(telegram_id) DO UPDATE SET
                 max_duration_minutes = excluded.max_duration_minutes,
                 set_at = excluded.set_at,
-                set_by = excluded.set_by
+                set_by = excluded.set_by,
+                one_time = excluded.one_time
             """,
-            (telegram_id, max_duration_minutes, now, set_by),
+            (telegram_id, max_duration_minutes, now, set_by, 1 if one_time else 0),
         )
 
     def remove_limit(self, telegram_id: int) -> bool:
@@ -46,10 +57,22 @@ class DurationLimitService:
         )
         return rowcount > 0
 
+    def consume_one_time_limit(self, telegram_id: int) -> bool:
+        """Clear the user's limit if it is one-time. Returns True if cleared.
+
+        Called after a successful booking so a single-use limit does not carry
+        over to future bookings. Ongoing limits are left untouched.
+        """
+        rowcount = self.db.execute_write(
+            "DELETE FROM duration_limits WHERE telegram_id = ? AND one_time = 1",
+            (telegram_id,),
+        )
+        return rowcount > 0
+
     def get_all_limits(self) -> list[dict]:
         """Get all duration limits."""
         rows = self.db.execute(
-            "SELECT telegram_id, max_duration_minutes, set_at, set_by "
+            "SELECT telegram_id, max_duration_minutes, set_at, set_by, one_time "
             "FROM duration_limits ORDER BY set_at DESC"
         )
         return [
@@ -58,6 +81,7 @@ class DurationLimitService:
                 "max_duration_minutes": row["max_duration_minutes"],
                 "set_at": row["set_at"],
                 "set_by": row["set_by"],
+                "one_time": bool(row["one_time"]),
             }
             for row in rows
         ]

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -754,6 +754,51 @@ class TestConfirmBooking:
         assert request.eventTypeId == 30
 
     @pytest.mark.asyncio
+    async def test_consumes_one_time_limit_after_successful_booking(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        booking_response,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {**user_data_ready, "duration": 30}
+        mock_calcom_client.create_booking.return_value = booking_response
+        duration_limit_service = MagicMock()
+        duration_limit_service.get_limit.return_value = 30
+        mock_context.bot_data["duration_limit_service"] = duration_limit_service
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            await confirm_booking(mock_update_with_query, mock_context)
+
+        duration_limit_service.consume_one_time_limit.assert_called_once_with(12345)
+
+    @pytest.mark.asyncio
+    async def test_does_not_consume_limit_when_booking_fails(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {**user_data_ready, "duration": 30}
+        mock_calcom_client.create_booking.side_effect = CalComAPIError(
+            status_code=409, message="conflict"
+        )
+        duration_limit_service = MagicMock()
+        duration_limit_service.get_limit.return_value = 30
+        mock_context.bot_data["duration_limit_service"] = duration_limit_service
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            await confirm_booking(mock_update_with_query, mock_context)
+
+        duration_limit_service.consume_one_time_limit.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_returns_conversation_end_on_success(
         self,
         mock_update_with_query,

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -799,6 +799,35 @@ class TestConfirmBooking:
         duration_limit_service.consume_one_time_limit.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_one_time_cleanup_failure_still_confirms_booking(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        booking_response,
+    ):
+        from telegram.ext import ConversationHandler
+
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {**user_data_ready, "duration": 30}
+        mock_calcom_client.create_booking.return_value = booking_response
+        duration_limit_service = MagicMock()
+        duration_limit_service.get_limit.return_value = 30
+        duration_limit_service.consume_one_time_limit.side_effect = Exception("db locked")
+        mock_context.bot_data["duration_limit_service"] = duration_limit_service
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            result = await confirm_booking(mock_update_with_query, mock_context)
+
+        # Cal.com already accepted the booking; a cleanup failure must not turn
+        # into a "try again" error that risks a duplicate booking.
+        assert result == ConversationHandler.END
+        final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
+        assert "подтверждена" in final_message.lower() or "готово" in final_message.lower()
+
+    @pytest.mark.asyncio
     async def test_returns_conversation_end_on_success(
         self,
         mock_update_with_query,

--- a/tests/test_duration_limit.py
+++ b/tests/test_duration_limit.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.database import Database
-from app.database.migrations import initialize_schema
+from app.database.migrations import initialize_schema, run_migrations
 from app.handlers.duration_limit import (
     limits_command,
     removelimit_command,
@@ -204,3 +204,128 @@ class TestLimitsCommand:
         assert "222" in reply
         assert "30" in reply
         assert "60" in reply
+
+
+# ===========================================================================
+# One-time scope: service
+# ===========================================================================
+
+
+class TestOneTimeScope:
+    def test_set_limit_defaults_to_one_time(self, duration_limit_service):
+        duration_limit_service.set_limit(111, 30, set_by=1)
+        assert duration_limit_service.get_all_limits()[0]["one_time"] is True
+
+    def test_set_limit_can_be_ongoing(self, duration_limit_service):
+        duration_limit_service.set_limit(111, 30, set_by=1, one_time=False)
+        assert duration_limit_service.get_all_limits()[0]["one_time"] is False
+
+    def test_consume_clears_one_time_limit(self, duration_limit_service):
+        duration_limit_service.set_limit(111, 30, set_by=1, one_time=True)
+        assert duration_limit_service.consume_one_time_limit(111) is True
+        assert duration_limit_service.get_limit(111) is None
+
+    def test_consume_leaves_ongoing_limit(self, duration_limit_service):
+        duration_limit_service.set_limit(111, 30, set_by=1, one_time=False)
+        assert duration_limit_service.consume_one_time_limit(111) is False
+        assert duration_limit_service.get_limit(111) == 30
+
+    def test_consume_returns_false_for_unknown_user(self, duration_limit_service):
+        assert duration_limit_service.consume_one_time_limit(999) is False
+
+    def test_reset_changes_scope(self, duration_limit_service):
+        duration_limit_service.set_limit(111, 30, set_by=1, one_time=False)
+        duration_limit_service.set_limit(111, 30, set_by=1, one_time=True)
+        assert duration_limit_service.get_all_limits()[0]["one_time"] is True
+
+
+# ===========================================================================
+# One-time scope: migration of pre-existing databases
+# ===========================================================================
+
+
+class TestOneTimeScopeMigration:
+    def test_adds_one_time_column_to_legacy_table(self, temp_db_path):
+        db = Database(temp_db_path)
+        db.execute_write(
+            "CREATE TABLE duration_limits ("
+            "telegram_id INTEGER PRIMARY KEY, "
+            "max_duration_minutes INTEGER NOT NULL, "
+            "set_at TEXT NOT NULL, "
+            "set_by INTEGER NOT NULL)"
+        )
+        db.execute_write(
+            "INSERT INTO duration_limits "
+            "(telegram_id, max_duration_minutes, set_at, set_by) "
+            "VALUES (?, ?, ?, ?)",
+            (111, 60, "2026-01-01T00:00:00+00:00", 1),
+        )
+
+        run_migrations(db)
+
+        columns = {row["name"] for row in db.execute("PRAGMA table_info(duration_limits)")}
+        assert "one_time" in columns
+        # Limits that predate the column are treated as ongoing.
+        assert DurationLimitService(db).get_all_limits()[0]["one_time"] is False
+
+    def test_migration_is_idempotent(self, temp_db_path):
+        db = Database(temp_db_path)
+        run_migrations(db)
+        run_migrations(db)
+        columns = {row["name"] for row in db.execute("PRAGMA table_info(duration_limits)")}
+        assert "one_time" in columns
+
+
+# ===========================================================================
+# One-time scope: /setlimit command parsing
+# ===========================================================================
+
+
+class TestSetlimitScope:
+    @pytest.mark.asyncio
+    async def test_defaults_to_one_time(
+        self, mock_update, mock_context, duration_limit_service
+    ):
+        mock_context.args = ["555", "30"]
+        await setlimit_command(mock_update, mock_context)
+
+        assert duration_limit_service.get_all_limits()[0]["one_time"] is True
+        reply = mock_update.message.reply_text.call_args[0][0]
+        assert "разов" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_ongoing_with_keyword(
+        self, mock_update, mock_context, duration_limit_service
+    ):
+        mock_context.args = ["555", "30", "постоянно"]
+        await setlimit_command(mock_update, mock_context)
+
+        assert duration_limit_service.get_limit(555) == 30
+        assert duration_limit_service.get_all_limits()[0]["one_time"] is False
+        reply = mock_update.message.reply_text.call_args[0][0]
+        assert "постоянн" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_ongoing_keyword_by_reply(
+        self, mock_update, mock_context, duration_limit_service
+    ):
+        mock_update.message.reply_to_message = MagicMock()
+        mock_update.message.reply_to_message.from_user = MagicMock()
+        mock_update.message.reply_to_message.from_user.id = 777
+        mock_context.args = ["60", "always"]
+        await setlimit_command(mock_update, mock_context)
+
+        assert duration_limit_service.get_limit(777) == 60
+        assert duration_limit_service.get_all_limits()[0]["one_time"] is False
+
+    @pytest.mark.asyncio
+    async def test_limits_command_shows_scope(
+        self, mock_update, mock_context, duration_limit_service
+    ):
+        duration_limit_service.set_limit(111, 30, set_by=1, one_time=True)
+        duration_limit_service.set_limit(222, 60, set_by=1, one_time=False)
+        await limits_command(mock_update, mock_context)
+
+        reply = mock_update.message.reply_text.call_args[0][0]
+        assert "разовый" in reply.lower()
+        assert "постоянный" in reply.lower()


### PR DESCRIPTION
## Summary

Builds on #60 (enforcement at booking time). Adds a **scope** to per-user duration limits so a temporary cap cleans itself up.

- **One-time is the default.** A limit applies to the user's next successful booking, then clears itself — no manual `/removelimit` needed for the common "ease someone back in" case.
- **Ongoing** limits are still available via a trailing keyword (`постоянно` / `always`).
- **Silent.** The bookee gets no notice. This matches the existing behavior: a limited user never sees the longer option — the picker is skipped and the capped duration is auto-selected.

## Changes

- **Schema:** `duration_limits.one_time` column. Idempotent `ALTER TABLE` migration for existing DBs; pre-existing limits are treated as ongoing (default 0).
- **Service:** `set_limit(..., one_time=True)` default; new `consume_one_time_limit()` deletes the row only when `one_time = 1` (no-op for ongoing).
- **Booking:** `confirm_booking` consumes the one-time limit **only after** a successful Cal.com booking — a failed booking leaves the cap in place.
- **Admin:** `/setlimit <id> <min> [постоянно]` parses an optional trailing scope keyword (default one-time); `/limits` and the confirmation message show the scope.

## Design notes

- Default flipped to one-time per product decision: the motivating case (someone who's been away) is temporary, and an auto-expiring limit removes the ongoing-management burden.
- Enforcement chosen silent over a booking-time note — quietest experience, no sense of being singled out. The ongoing scope + `/limits` keep the admin side legible.

## Validation

- `uv run pytest tests/ -q` → 224 passed
- `uv run ruff check .` → clean

New tests cover: scope default/override at the service and `/setlimit` layers, `consume_one_time_limit` clear/no-op/unknown, consume-after-success and no-consume-on-failure in `confirm_booking`, and the legacy-DB column migration (incl. idempotency).

> Note: stacked on `codex/enforce-duration-limit` (#60). Retarget to `main` once #60 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)