### PR TITLE
Support native two-hour bookings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from pydantic_settings import BaseSettings
 
+from app.constants import SUPPORTED_BOOKING_DURATIONS
+
 
 @dataclass(frozen=True)
 class ResolvedEventType:
@@ -77,7 +79,7 @@ class Settings(BaseSettings):
 
     def validate_event_type_configuration(self) -> None:
         """Fail startup unless every supported duration can be resolved."""
-        for duration_minutes in (30, 60, 120):
+        for duration_minutes in SUPPORTED_BOOKING_DURATIONS:
             self.resolve_event_type(duration_minutes)
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,16 @@
 """Application configuration loaded from environment variables."""
 
+from dataclasses import dataclass
+
 from pydantic_settings import BaseSettings
+
+
+@dataclass(frozen=True)
+class ResolvedEventType:
+    """Cal.com event type and any duration override it requires."""
+
+    event_type_id: int
+    duration_minutes: int | None
 
 
 class Settings(BaseSettings):
@@ -32,25 +42,43 @@ class Settings(BaseSettings):
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 
-    def get_event_type_id(self, duration_minutes: int) -> int:
-        """Get the event type ID for a given duration, with fallback.
+    def resolve_event_type(self, duration_minutes: int) -> ResolvedEventType:
+        """Resolve an event type and the duration override Cal.com expects.
 
         Raises:
             ValueError: If no event type ID is configured for the given duration.
         """
         if duration_minutes == 30:
-            result = self.calcom_event_type_id_30 or self.calcom_event_type_id
+            specific_event_type_id = self.calcom_event_type_id_30
         elif duration_minutes == 60:
-            result = self.calcom_event_type_id_60 or self.calcom_event_type_id
+            specific_event_type_id = self.calcom_event_type_id_60
         else:
-            result = self.calcom_event_type_id
+            specific_event_type_id = None
 
-        if result is None:
+        if specific_event_type_id is not None:
+            return ResolvedEventType(
+                event_type_id=specific_event_type_id,
+                duration_minutes=None,
+            )
+
+        if self.calcom_event_type_id is None:
             raise ValueError(
                 f"No event type ID configured for {duration_minutes}-minute duration. "
                 "Set CALCOM_EVENT_TYPE_ID or duration-specific IDs in config."
             )
-        return result
+        return ResolvedEventType(
+            event_type_id=self.calcom_event_type_id,
+            duration_minutes=duration_minutes,
+        )
+
+    def get_event_type_id(self, duration_minutes: int) -> int:
+        """Get the resolved event type ID for a given duration."""
+        return self.resolve_event_type(duration_minutes).event_type_id
+
+    def validate_event_type_configuration(self) -> None:
+        """Fail startup unless every supported duration can be resolved."""
+        for duration_minutes in (30, 60, 120):
+            self.resolve_event_type(duration_minutes)
 
 
 # Global settings instance

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,5 +1,7 @@
 """Constants used throughout the application."""
 
+SUPPORTED_BOOKING_DURATIONS = (30, 60, 120)
+
 # Russian timezones sorted by UTC offset
 RUSSIAN_TIMEZONES = [
     ("Europe/Kaliningrad", "Калининград (UTC+2)"),

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -59,7 +59,14 @@ RUSSIAN_MONTHS_ABBR = [
 TIMEZONE_BUTTON_LABEL = "Часовой пояс"
 MAX_NAME_LENGTH = 100
 
-DURATION_OPTIONS = {30: "30 минут", 60: "60 минут"}
+DURATION_OPTIONS = {30: "30 минут", 60: "60 минут", 120: "120 минут"}
+FIFTH_STEP_WARNING_TEXT = (
+    "Важно: двухчасовые встречи предназначены только для работы по 5-му шагу.\n\n"
+    "Если вы записываетесь не для 5-го шага, пожалуйста, выберите длительность "
+    "30 или 60 минут."
+)
+FIFTH_STEP_CONFIRM_CALLBACK = "duration_120_confirm"
+CHANGE_DURATION_CALLBACK = "change_duration"
 CANCEL_SELECT_PREFIX = "cancel_booking_select:"
 CANCEL_CONFIRM_PREFIX = "cancel_booking_confirm:"
 CANCEL_BACK_CALLBACK = "cancel_booking_back"
@@ -293,12 +300,19 @@ async def _handle_duration_selection(query, context: ContextTypes.DEFAULT_TYPE) 
     max_duration = _get_duration_limit(context, user_id)
 
     if max_duration is not None:
+        if max_duration == 120:
+            return await _show_fifth_step_warning(query, context)
         # User has a limit — auto-select that duration, skip picker
         context.user_data["duration"] = max_duration
         return await _show_availability(query, context, offset_days=0)
 
-    # No limit — show duration selection
-    keyboard = build_duration_keyboard()
+    return await _show_duration_picker(query, context)
+
+
+async def _show_duration_picker(query, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Show durations allowed by the user's current limit."""
+    max_duration = _get_duration_limit(context, query.from_user.id)
+    keyboard = build_duration_keyboard(max_duration=max_duration)
     await _safe_edit_message_text(
         query,
         "Выберите длительность встречи:",
@@ -321,10 +335,65 @@ async def select_duration(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return BookingState.SELECTING_DURATION
 
     duration = _apply_current_duration_limit(context, query.from_user.id, duration)
-    context.user_data["duration"] = duration
     _refresh_booking_timeout_reminder(context, query.from_user.id)
 
+    if duration == 120:
+        return await _show_fifth_step_warning(query, context)
+
+    context.user_data["duration"] = duration
+    context.user_data.pop("pending_duration", None)
     return await _show_availability(query, context, offset_days=0)
+
+
+async def _show_fifth_step_warning(query, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Require acknowledgement before showing 120-minute availability."""
+    context.user_data.pop("duration", None)
+    context.user_data["pending_duration"] = 120
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "Продолжить (5-й шаг)",
+                    callback_data=FIFTH_STEP_CONFIRM_CALLBACK,
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "Изменить длительность",
+                    callback_data=CHANGE_DURATION_CALLBACK,
+                )
+            ],
+        ]
+    )
+    await _safe_edit_message_text(query, FIFTH_STEP_WARNING_TEXT, reply_markup=keyboard)
+    return BookingState.SELECTING_DURATION
+
+
+async def acknowledge_fifth_step_duration(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Continue to availability after acknowledging fifth-step-only usage."""
+    query = update.callback_query
+    await query.answer()
+    _refresh_booking_timeout_reminder(context, query.from_user.id)
+
+    if context.user_data.get("pending_duration") != 120:
+        return await _show_duration_picker(query, context)
+
+    duration = _apply_current_duration_limit(context, query.from_user.id, 120)
+    context.user_data.pop("pending_duration", None)
+    context.user_data["duration"] = duration
+    return await _show_availability(query, context, offset_days=0)
+
+
+async def change_duration(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Return from the fifth-step warning to duration selection."""
+    query = update.callback_query
+    await query.answer()
+    _refresh_booking_timeout_reminder(context, query.from_user.id)
+    context.user_data.pop("pending_duration", None)
+    context.user_data.pop("duration", None)
+    return await _show_duration_picker(query, context)
 
 
 async def change_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -371,6 +440,7 @@ async def _show_availability(
             start_date=today + timedelta(days=offset_days),
             end_date=today + timedelta(days=offset_days + 14),
             timezone=timezone_id,
+            duration_minutes=duration,
         )
 
         has_slots = any(availability.slots.values())
@@ -554,12 +624,18 @@ def _build_confirmation_text(data: dict) -> str:
     duration = data.get("duration", 30)
     duration_text = DURATION_OPTIONS.get(duration, f"{duration} мин.")
     email_line = f"\nEmail: {data['email']}" if data.get("email") else ""
+    fifth_step_warning = (
+        "\n\nВажно: двухчасовые встречи предназначены только для работы по 5-му шагу."
+        if duration == 120
+        else ""
+    )
     return (
         f"Подтвердите запись:\n\n"
         f"Время: {formatted_time}\n"
         f"Длительность: {duration_text}\n"
         f"Имя: {data['name']}"
-        f"{email_line}\n\n"
+        f"{email_line}"
+        f"{fifth_step_warning}\n\n"
         f"Нажмите «Подтвердить запись» для продолжения."
     )
 
@@ -618,6 +694,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             BookingRequest(
                 eventTypeId=event_type_id,
                 start=start_utc,
+                lengthInMinutes=duration,
                 attendee=Attendee(
                     name=data["name"],
                     email=email,
@@ -931,11 +1008,12 @@ def build_timezone_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(buttons)
 
 
-def build_duration_keyboard() -> InlineKeyboardMarkup:
+def build_duration_keyboard(max_duration: int | None = None) -> InlineKeyboardMarkup:
     """Build duration selection keyboard."""
     buttons = [
         [InlineKeyboardButton(label, callback_data=f"duration:{minutes}")]
         for minutes, label in DURATION_OPTIONS.items()
+        if max_duration is None or minutes <= max_duration
     ]
     buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
     return InlineKeyboardMarkup(buttons)
@@ -1100,6 +1178,11 @@ def create_booking_conversation_handler() -> ConversationHandler:
             ],
             BookingState.SELECTING_DURATION: [
                 CallbackQueryHandler(select_duration, pattern="^duration:"),
+                CallbackQueryHandler(
+                    acknowledge_fifth_step_duration,
+                    pattern=f"^{FIFTH_STEP_CONFIRM_CALLBACK}$",
+                ),
+                CallbackQueryHandler(change_duration, pattern=f"^{CHANGE_DURATION_CALLBACK}$"),
                 CallbackQueryHandler(cancel, pattern="^cancel$"),
             ],
             BookingState.VIEWING_AVAILABILITY: [

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -60,8 +60,11 @@ TIMEZONE_BUTTON_LABEL = "Часовой пояс"
 MAX_NAME_LENGTH = 100
 
 DURATION_OPTIONS = {30: "30 минут", 60: "60 минут", 120: "120 минут"}
+FIFTH_STEP_RESTRICTION_TEXT = (
+    "двухчасовые встречи предназначены только для работы по 5-му шагу."
+)
 FIFTH_STEP_WARNING_TEXT = (
-    "Важно: двухчасовые встречи предназначены только для работы по 5-му шагу.\n\n"
+    f"Важно: {FIFTH_STEP_RESTRICTION_TEXT}\n\n"
     "Если вы записываетесь не для 5-го шага, пожалуйста, выберите длительность "
     "30 или 60 минут."
 )
@@ -303,6 +306,7 @@ async def _handle_duration_selection(query, context: ContextTypes.DEFAULT_TYPE) 
         if max_duration == 120:
             return await _show_fifth_step_warning(query, context)
         # User has a limit — auto-select that duration, skip picker
+        context.user_data.pop("pending_duration", None)
         context.user_data["duration"] = max_duration
         return await _show_availability(query, context, offset_days=0)
 
@@ -431,16 +435,16 @@ async def _show_availability(
         context.user_data.get("duration", 30),
     )
     context.user_data["duration"] = duration
-    event_type_id = settings.get_event_type_id(duration)
     today = date.today()
 
     try:
+        resolved_event_type = settings.resolve_event_type(duration)
         availability = await calcom_client.get_availability(
-            event_type_id=event_type_id,
+            event_type_id=resolved_event_type.event_type_id,
             start_date=today + timedelta(days=offset_days),
             end_date=today + timedelta(days=offset_days + 14),
             timezone=timezone_id,
-            duration_minutes=duration,
+            duration_minutes=resolved_event_type.duration_minutes,
         )
 
         has_slots = any(availability.slots.values())
@@ -467,7 +471,12 @@ async def _show_availability(
         )
         return BookingState.VIEWING_AVAILABILITY
 
-    except CalComAPIError:
+    except (CalComAPIError, ValueError):
+        logger.exception(
+            "Failed to load availability for user_id=%s duration=%s",
+            query.from_user.id,
+            duration,
+        )
         await _safe_edit_message_text(
             query,
             "Извините, не удалось загрузить расписание. Попробуйте ещё раз.",
@@ -625,7 +634,7 @@ def _build_confirmation_text(data: dict) -> str:
     duration_text = DURATION_OPTIONS.get(duration, f"{duration} мин.")
     email_line = f"\nEmail: {data['email']}" if data.get("email") else ""
     fifth_step_warning = (
-        "\n\nВажно: двухчасовые встречи предназначены только для работы по 5-му шагу."
+        f"\n\nВажно: {FIFTH_STEP_RESTRICTION_TEXT}"
         if duration == 120
         else ""
     )
@@ -678,23 +687,23 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         data.get("duration", 30),
     )
     data["duration"] = duration
-    event_type_id = settings.get_event_type_id(duration)
 
     try:
+        resolved_event_type = settings.resolve_event_type(duration)
         start_utc = slot_to_utc(data["selected_time"])
         logger.info(
             "Creating booking for user_id=%s event_type_id=%s start_utc=%s timezone=%s",
             update.effective_user.id,
-            event_type_id,
+            resolved_event_type.event_type_id,
             start_utc,
             data.get("timezone"),
         )
 
         booking = await calcom_client.create_booking(
             BookingRequest(
-                eventTypeId=event_type_id,
+                eventTypeId=resolved_event_type.event_type_id,
                 start=start_utc,
-                lengthInMinutes=duration,
+                lengthInMinutes=resolved_event_type.duration_minutes,
                 attendee=Attendee(
                     name=data["name"],
                     email=email,

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -17,7 +17,7 @@ from telegram.ext import (
 )
 
 from app.config import settings
-from app.constants import RUSSIAN_TIMEZONES
+from app.constants import RUSSIAN_TIMEZONES, SUPPORTED_BOOKING_DURATIONS
 from app.services.booking_service import BookingService
 from app.services.calcom_client import (
     Attendee,
@@ -59,7 +59,9 @@ RUSSIAN_MONTHS_ABBR = [
 TIMEZONE_BUTTON_LABEL = "Часовой пояс"
 MAX_NAME_LENGTH = 100
 
-DURATION_OPTIONS = {30: "30 минут", 60: "60 минут", 120: "120 минут"}
+DURATION_OPTIONS = {
+    minutes: f"{minutes} минут" for minutes in SUPPORTED_BOOKING_DURATIONS
+}
 FIFTH_STEP_RESTRICTION_TEXT = (
     "двухчасовые встречи предназначены только для работы по 5-му шагу."
 )

--- a/app/handlers/duration_limit.py
+++ b/app/handlers/duration_limit.py
@@ -5,13 +5,11 @@ import logging
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from app.constants import SUPPORTED_BOOKING_DURATIONS
 from app.handlers.admin import admin_only
 from app.services.duration_limit import DurationLimitService
 
 logger = logging.getLogger(__name__)
-
-VALID_DURATIONS = (30, 60, 120)
-
 
 @admin_only
 async def setlimit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -56,9 +54,10 @@ async def setlimit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await update.message.reply_text("Telegram ID и минуты должны быть числами.")
             return
 
-    if minutes not in VALID_DURATIONS:
+    if minutes not in SUPPORTED_BOOKING_DURATIONS:
         await update.message.reply_text(
-            f"Допустимые значения: {', '.join(str(d) for d in VALID_DURATIONS)} минут."
+            "Допустимые значения: "
+            f"{', '.join(str(d) for d in SUPPORTED_BOOKING_DURATIONS)} минут."
         )
         return
 

--- a/app/handlers/duration_limit.py
+++ b/app/handlers/duration_limit.py
@@ -10,7 +10,7 @@ from app.services.duration_limit import DurationLimitService
 
 logger = logging.getLogger(__name__)
 
-VALID_DURATIONS = (30, 60)
+VALID_DURATIONS = (30, 60, 120)
 
 
 @admin_only

--- a/app/main.py
+++ b/app/main.py
@@ -66,6 +66,8 @@ def main() -> None:
 
     logger.info("Initializing Telecalbot...")
 
+    settings.validate_event_type_configuration()
+
     # Initialize database
     run_migrations(db)
     logger.info(f"Database initialized at {settings.database_path}")

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -51,7 +51,7 @@ class BookingRequest(BaseModel):
 
     eventTypeId: int
     start: str  # ISO 8601 UTC datetime
-    lengthInMinutes: int
+    lengthInMinutes: int | None = None
     attendee: Attendee
     metadata: dict[str, Any] = {}
 
@@ -118,7 +118,7 @@ class CalComClient:
         start_date: date,
         end_date: date,
         timezone: str,
-        duration_minutes: int,
+        duration_minutes: int | None,
     ) -> AvailabilityResponse:
         """Get available time slots for an event type.
 
@@ -127,7 +127,7 @@ class CalComClient:
             start_date: Start date for availability search.
             end_date: End date for availability search.
             timezone: User's timezone (e.g., "Europe/Moscow").
-            duration_minutes: Required duration for each returned slot.
+            duration_minutes: Duration override, or None for fixed-duration event types.
 
         Returns:
             AvailabilityResponse with available slots grouped by date.
@@ -147,16 +147,19 @@ class CalComClient:
         logger.debug("Cache miss for availability: %s", cache_key)
 
         # Fetch from API
+        params = {
+            "eventTypeId": event_type_id,
+            "startTime": f"{start_date}T00:00:00Z",
+            "endTime": f"{end_date}T23:59:59Z",
+            "timeZone": timezone,
+        }
+        if duration_minutes is not None:
+            params["duration"] = duration_minutes
+
         response = await self._request(
             "GET",
             "/slots/available",
-            params={
-                "eventTypeId": event_type_id,
-                "startTime": f"{start_date}T00:00:00Z",
-                "endTime": f"{end_date}T23:59:59Z",
-                "timeZone": timezone,
-                "duration": duration_minutes,
-            },
+            params=params,
         )
 
         data = AvailabilityResponse.model_validate(response["data"])
@@ -178,7 +181,7 @@ class CalComClient:
         response = await self._request(
             "POST",
             "/bookings",
-            json=request.model_dump(),
+            json=request.model_dump(exclude_none=True),
         )
 
         # Clear availability cache on successful booking

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -51,6 +51,7 @@ class BookingRequest(BaseModel):
 
     eventTypeId: int
     start: str  # ISO 8601 UTC datetime
+    lengthInMinutes: int
     attendee: Attendee
     metadata: dict[str, Any] = {}
 
@@ -117,6 +118,7 @@ class CalComClient:
         start_date: date,
         end_date: date,
         timezone: str,
+        duration_minutes: int,
     ) -> AvailabilityResponse:
         """Get available time slots for an event type.
 
@@ -125,6 +127,7 @@ class CalComClient:
             start_date: Start date for availability search.
             end_date: End date for availability search.
             timezone: User's timezone (e.g., "Europe/Moscow").
+            duration_minutes: Required duration for each returned slot.
 
         Returns:
             AvailabilityResponse with available slots grouped by date.
@@ -132,7 +135,7 @@ class CalComClient:
         Raises:
             CalComAPIError: If API request fails.
         """
-        cache_key = (event_type_id, start_date, end_date, timezone)
+        cache_key = (event_type_id, start_date, end_date, timezone, duration_minutes)
 
         # Check cache
         if cache_key in self._availability_cache:
@@ -152,6 +155,7 @@ class CalComClient:
                 "startTime": f"{start_date}T00:00:00Z",
                 "endTime": f"{end_date}T23:59:59Z",
                 "timeZone": timezone,
+                "duration": duration_minutes,
             },
         )
 

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -751,6 +751,28 @@ class TestConfirmBooking:
         assert request.lengthInMinutes is None
 
     @pytest.mark.asyncio
+    async def test_missing_event_mapping_shows_booking_error(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = user_data_ready
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            error = ValueError("No event type ID configured")
+            mock_settings.get_event_type_id.side_effect = error
+            mock_settings.resolve_event_type.side_effect = error
+            result = await confirm_booking(mock_update_with_query, mock_context)
+
+        assert result == BookingState.VIEWING_AVAILABILITY
+        mock_calcom_client.create_booking.assert_not_called()
+        message = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
+        assert "что-то пошло не так" in message
+
+    @pytest.mark.asyncio
     async def test_applies_current_duration_limit_when_confirming(
         self,
         mock_update_with_query,

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -724,6 +724,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.assert_called_once()
         request = mock_calcom_client.create_booking.call_args[0][0]
         assert request.eventTypeId == 42
+        assert request.lengthInMinutes == 30
         assert request.attendee.name == "Alice"
         assert request.attendee.email == "alice@example.com"
         assert request.attendee.timeZone == "Europe/Moscow"
@@ -752,6 +753,7 @@ class TestConfirmBooking:
         mock_settings.get_event_type_id.assert_called_once_with(30)
         request = mock_calcom_client.create_booking.call_args[0][0]
         assert request.eventTypeId == 30
+        assert request.lengthInMinutes == 30
 
     @pytest.mark.asyncio
     async def test_returns_conversation_end_on_success(

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -731,6 +731,26 @@ class TestConfirmBooking:
         assert "telegram_user_id" in request.metadata
 
     @pytest.mark.asyncio
+    async def test_fixed_duration_event_omits_booking_length_override(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        booking_response,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = user_data_ready
+        mock_calcom_client.create_booking.return_value = booking_response
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id.return_value = 42
+            await confirm_booking(mock_update_with_query, mock_context)
+
+        request = mock_calcom_client.create_booking.call_args.args[0]
+        assert request.lengthInMinutes is None
+
+    @pytest.mark.asyncio
     async def test_applies_current_duration_limit_when_confirming(
         self,
         mock_update_with_query,

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -7,6 +7,7 @@ import pytest
 from telegram.error import BadRequest
 from telegram.ext import ConversationHandler
 
+from app.config import ResolvedEventType
 from app.constants import RUSSIAN_TIMEZONES
 from app.handlers.booking import (
     BookingState,
@@ -42,6 +43,15 @@ from app.services.calcom_client import (
     CalComAPIError,
     TimeSlot,
 )
+
+
+def _resolved_event_type(
+    duration_minutes: int, event_type_id: int = 42
+) -> ResolvedEventType:
+    return ResolvedEventType(
+        event_type_id=event_type_id,
+        duration_minutes=duration_minutes,
+    )
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -343,7 +353,7 @@ class TestSelectTimezone:
         mock_calcom_client.get_availability.return_value = availability_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await select_timezone(mock_update_with_query, mock_context)
 
         assert mock_context.user_data["timezone"] == "Europe/Moscow"
@@ -376,7 +386,7 @@ class TestSelectTimezone:
         }
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await select_timezone(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
@@ -412,7 +422,7 @@ class TestSelectTimezone:
         }
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await select_timezone(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
@@ -718,7 +728,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await confirm_booking(mock_update_with_query, mock_context)
 
         mock_calcom_client.create_booking.assert_called_once()
@@ -744,7 +754,10 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id.return_value = 42
+            mock_settings.resolve_event_type.return_value = ResolvedEventType(
+                event_type_id=42,
+                duration_minutes=None,
+            )
             await confirm_booking(mock_update_with_query, mock_context)
 
         request = mock_calcom_client.create_booking.call_args.args[0]
@@ -763,7 +776,6 @@ class TestConfirmBooking:
 
         with patch("app.handlers.booking.settings") as mock_settings:
             error = ValueError("No event type ID configured")
-            mock_settings.get_event_type_id.side_effect = error
             mock_settings.resolve_event_type.side_effect = error
             result = await confirm_booking(mock_update_with_query, mock_context)
 
@@ -789,10 +801,12 @@ class TestConfirmBooking:
         mock_context.bot_data["duration_limit_service"] = duration_limit_service
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            mock_settings.resolve_event_type.side_effect = lambda duration: (
+                _resolved_event_type(duration, event_type_id=duration)
+            )
             await confirm_booking(mock_update_with_query, mock_context)
 
-        mock_settings.get_event_type_id.assert_called_once_with(30)
+        mock_settings.resolve_event_type.assert_called_once_with(30)
         request = mock_calcom_client.create_booking.call_args[0][0]
         assert request.eventTypeId == 30
         assert request.lengthInMinutes == 30
@@ -813,7 +827,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await confirm_booking(mock_update_with_query, mock_context)
 
         assert result == ConversationHandler.END
@@ -832,7 +846,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await confirm_booking(mock_update_with_query, mock_context)
 
         final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
@@ -879,7 +893,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await confirm_booking(mock_update_with_query, mock_context)
 
         request = mock_calcom_client.create_booking.call_args[0][0]
@@ -899,7 +913,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.side_effect = CalComAPIError(409, "Conflict")
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await confirm_booking(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
@@ -919,7 +933,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.side_effect = CalComAPIError(500, "Server error")
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await confirm_booking(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
@@ -945,7 +959,7 @@ class TestConfirmBooking:
         )
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await confirm_booking(mock_update_with_query, mock_context)
 
         final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
@@ -965,7 +979,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await confirm_booking(mock_update_with_query, mock_context)
 
         final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
@@ -985,7 +999,7 @@ class TestConfirmBooking:
         mock_calcom_client.create_booking.return_value = booking_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await confirm_booking(mock_update_with_query, mock_context)
 
         final_message = mock_update_with_query.callback_query.edit_message_text.call_args[0][0]
@@ -1161,7 +1175,7 @@ class TestBookingTimeoutReminderLifecycle:
         with patch("app.handlers.booking.settings") as mock_settings:
             mock_settings.booking_conversation_timeout_seconds = 900
             mock_settings.booking_conversation_reminder_seconds_before_timeout = 120
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
 
             result = await confirm_booking(mock_update_with_query, mock_context)
 
@@ -1380,7 +1394,7 @@ class TestLoadMoreDates:
         mock_calcom_client.get_availability.return_value = availability_response
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await load_more_dates(mock_update_with_query, mock_context)
 
         assert mock_context.user_data["offset_days"] == 5

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -205,6 +205,21 @@ class TestFifthStepAcknowledgement:
         ]
         assert button_texts == ["30 минут", "60 минут", "120 минут", "Отмена"]
 
+    @pytest.mark.asyncio
+    async def test_stale_acknowledgement_without_pending_duration_returns_to_picker(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "duration_120_confirm"
+        mock_context.user_data = {"timezone": "Europe/Moscow"}
+
+        result = await booking_handler.acknowledge_fifth_step_duration(
+            mock_update_with_query, mock_context
+        )
+
+        assert result == BookingState.SELECTING_DURATION
+        call_text = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
+        assert "длительность" in call_text.lower()
+
 
 class TestSelectDurationValidation:
     """Tests for invalid callback data in duration selection."""
@@ -253,6 +268,27 @@ class TestDurationLimitAutoSelect:
 
         assert result == BookingState.VIEWING_AVAILABILITY
         assert mock_context.user_data["duration"] == 30
+
+    @pytest.mark.asyncio
+    async def test_limited_user_auto_select_clears_pending_duration(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
+        mock_calcom = AsyncMock()
+        mock_calcom.get_availability.return_value = MagicMock(slots={})
+        mock_duration_service = MagicMock(spec=DurationLimitService)
+        mock_duration_service.get_limit.return_value = 60
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom,
+            "duration_limit_service": mock_duration_service,
+        }
+        mock_context.user_data = {"pending_duration": 120}
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id.return_value = 42
+            await select_timezone(mock_update_with_query, mock_context)
+
+        assert "pending_duration" not in mock_context.user_data
 
     @pytest.mark.asyncio
     async def test_120_minute_limit_requires_fifth_step_acknowledgement(

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -65,6 +65,31 @@ class TestDurationSelection:
         assert mock_context.user_data["duration"] == 60
 
     @pytest.mark.asyncio
+    async def test_select_duration_120_requires_fifth_step_acknowledgement(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "duration:120"
+        mock_calcom = AsyncMock()
+        mock_context.bot_data = {"calcom_client": mock_calcom}
+        mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
+
+        result = await select_duration(mock_update_with_query, mock_context)
+
+        assert result == BookingState.SELECTING_DURATION
+        assert mock_context.user_data["pending_duration"] == 120
+        mock_calcom.get_availability.assert_not_called()
+        warning_call = mock_update_with_query.callback_query.edit_message_text.call_args
+        warning_text = warning_call.args[0]
+        assert "двухчасовые встречи" in warning_text
+        assert "5-му шагу" in warning_text
+        button_texts = [
+            button.text
+            for row in warning_call.kwargs["reply_markup"].inline_keyboard
+            for button in row
+        ]
+        assert button_texts == ["Продолжить (5-й шаг)", "Изменить длительность"]
+
+    @pytest.mark.asyncio
     async def test_select_duration_caps_stale_callback_for_limited_user(
         self, mock_update_with_query, mock_context
     ):
@@ -150,6 +175,25 @@ class TestDurationLimitAutoSelect:
         assert mock_context.user_data["duration"] == 30
 
     @pytest.mark.asyncio
+    async def test_120_minute_limit_requires_fifth_step_acknowledgement(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
+        mock_calcom = AsyncMock()
+        mock_duration_service = MagicMock(spec=DurationLimitService)
+        mock_duration_service.get_limit.return_value = 120
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom,
+            "duration_limit_service": mock_duration_service,
+        }
+
+        result = await select_timezone(mock_update_with_query, mock_context)
+
+        assert result == BookingState.SELECTING_DURATION
+        assert mock_context.user_data["pending_duration"] == 120
+        mock_calcom.get_availability.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unlimited_user_sees_picker(self, mock_update_with_query, mock_context):
         """User without a limit should see the duration picker."""
         mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
@@ -205,3 +249,19 @@ class TestDurationInConfirmation:
         }
         text = _build_confirmation_text(data)
         assert "30 минут" in text
+
+    def test_confirmation_text_repeats_fifth_step_warning_for_120_minutes(self):
+        from app.handlers.booking import _build_confirmation_text
+
+        data = {
+            "selected_date": "2026-01-06",
+            "selected_time": "2026-01-06T10:00:00.000+03:00",
+            "timezone": "Europe/Moscow",
+            "name": "Alice",
+            "duration": 120,
+        }
+
+        text = _build_confirmation_text(data)
+
+        assert "120 минут" in text
+        assert "только для работы по 5-му шагу" in text

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -203,7 +203,7 @@ class TestFifthStepAcknowledgement:
             for row in call.kwargs["reply_markup"].inline_keyboard
             for button in row
         ]
-        assert button_texts == ["30 минут", "60 минут", "120 минут"]
+        assert button_texts == ["30 минут", "60 минут", "120 минут", "Отмена"]
 
 
 class TestSelectDurationValidation:
@@ -329,6 +329,7 @@ class TestDurationInConfirmation:
         }
         text = _build_confirmation_text(data)
         assert "30 минут" in text
+        assert "только для работы по 5-му шагу" not in text
 
     def test_confirmation_text_repeats_fifth_step_warning_for_120_minutes(self):
         from app.handlers.booking import _build_confirmation_text
@@ -345,3 +346,14 @@ class TestDurationInConfirmation:
 
         assert "120 минут" in text
         assert "только для работы по 5-му шагу" in text
+
+
+def test_duration_state_registers_fifth_step_warning_callbacks():
+    handler = booking_handler.create_booking_conversation_handler()
+    callbacks = {
+        callback.callback
+        for callback in handler.states[BookingState.SELECTING_DURATION]
+    }
+
+    assert booking_handler.acknowledge_fifth_step_duration in callbacks
+    assert booking_handler.change_duration in callbacks

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -126,6 +126,26 @@ class TestDurationSelection:
 
         assert result == BookingState.VIEWING_AVAILABILITY
 
+    @pytest.mark.asyncio
+    async def test_missing_event_mapping_shows_availability_error(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "duration:30"
+        mock_calcom = AsyncMock()
+        mock_context.bot_data = {"calcom_client": mock_calcom}
+        mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            error = ValueError("No event type ID configured")
+            mock_settings.get_event_type_id.side_effect = error
+            mock_settings.resolve_event_type.side_effect = error
+            result = await select_duration(mock_update_with_query, mock_context)
+
+        assert result == BookingState.VIEWING_AVAILABILITY
+        mock_calcom.get_availability.assert_not_called()
+        message = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
+        assert "не удалось загрузить расписание" in message
+
 
 class TestFifthStepAcknowledgement:
     @pytest.mark.asyncio

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.handlers import booking as booking_handler
 from app.handlers.booking import (
     BookingState,
     select_duration,
@@ -124,6 +125,85 @@ class TestDurationSelection:
             result = await select_duration(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
+
+
+class TestFifthStepAcknowledgement:
+    @pytest.mark.asyncio
+    async def test_acknowledgement_fetches_120_minute_availability(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "duration_120_confirm"
+        mock_calcom = AsyncMock()
+        mock_calcom.get_availability.return_value = MagicMock(slots={})
+        mock_context.bot_data = {"calcom_client": mock_calcom}
+        mock_context.user_data = {
+            "timezone": "Europe/Moscow",
+            "offset_days": 0,
+            "pending_duration": 120,
+        }
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id.return_value = 42
+            result = await booking_handler.acknowledge_fifth_step_duration(
+                mock_update_with_query, mock_context
+            )
+
+        assert result == BookingState.VIEWING_AVAILABILITY
+        assert mock_context.user_data["duration"] == 120
+        assert "pending_duration" not in mock_context.user_data
+        assert mock_calcom.get_availability.call_args.kwargs["duration_minutes"] == 120
+
+    @pytest.mark.asyncio
+    async def test_acknowledgement_reapplies_a_lowered_duration_limit(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "duration_120_confirm"
+        mock_calcom = AsyncMock()
+        mock_calcom.get_availability.return_value = MagicMock(slots={})
+        mock_duration_service = MagicMock(spec=DurationLimitService)
+        mock_duration_service.get_limit.return_value = 60
+        mock_context.bot_data = {
+            "calcom_client": mock_calcom,
+            "duration_limit_service": mock_duration_service,
+        }
+        mock_context.user_data = {
+            "timezone": "Europe/Moscow",
+            "offset_days": 0,
+            "pending_duration": 120,
+        }
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.get_event_type_id.side_effect = lambda duration: duration
+            await booking_handler.acknowledge_fifth_step_duration(
+                mock_update_with_query, mock_context
+            )
+
+        assert mock_context.user_data["duration"] == 60
+        assert mock_calcom.get_availability.call_args.kwargs["duration_minutes"] == 60
+
+    @pytest.mark.asyncio
+    async def test_change_duration_returns_to_all_allowed_options(
+        self, mock_update_with_query, mock_context
+    ):
+        mock_update_with_query.callback_query.data = "change_duration"
+        mock_duration_service = MagicMock(spec=DurationLimitService)
+        mock_duration_service.get_limit.return_value = 120
+        mock_context.bot_data = {"duration_limit_service": mock_duration_service}
+        mock_context.user_data = {"pending_duration": 120}
+
+        result = await booking_handler.change_duration(
+            mock_update_with_query, mock_context
+        )
+
+        assert result == BookingState.SELECTING_DURATION
+        assert "pending_duration" not in mock_context.user_data
+        call = mock_update_with_query.callback_query.edit_message_text.call_args
+        button_texts = [
+            button.text
+            for row in call.kwargs["reply_markup"].inline_keyboard
+            for button in row
+        ]
+        assert button_texts == ["30 минут", "60 минут", "120 минут"]
 
 
 class TestSelectDurationValidation:

--- a/tests/test_booking_duration.py
+++ b/tests/test_booking_duration.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.config import ResolvedEventType
 from app.handlers import booking as booking_handler
 from app.handlers.booking import (
     BookingState,
@@ -11,6 +12,15 @@ from app.handlers.booking import (
     select_timezone,
 )
 from app.services.duration_limit import DurationLimitService
+
+
+def _resolved_event_type(
+    duration_minutes: int, event_type_id: int = 42
+) -> ResolvedEventType:
+    return ResolvedEventType(
+        event_type_id=event_type_id,
+        duration_minutes=duration_minutes,
+    )
 
 
 @pytest.fixture
@@ -46,7 +56,7 @@ class TestDurationSelection:
         mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await select_duration(mock_update_with_query, mock_context)
 
         assert mock_context.user_data["duration"] == 30
@@ -60,7 +70,9 @@ class TestDurationSelection:
         mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=99)
+            mock_settings.resolve_event_type.side_effect = lambda duration: (
+                _resolved_event_type(duration, event_type_id=99)
+            )
             await select_duration(mock_update_with_query, mock_context)
 
         assert mock_context.user_data["duration"] == 60
@@ -106,11 +118,13 @@ class TestDurationSelection:
         mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(side_effect=lambda duration: duration)
+            mock_settings.resolve_event_type.side_effect = lambda duration: (
+                _resolved_event_type(duration, event_type_id=duration)
+            )
             await select_duration(mock_update_with_query, mock_context)
 
         assert mock_context.user_data["duration"] == 30
-        mock_settings.get_event_type_id.assert_called_once_with(30)
+        mock_settings.resolve_event_type.assert_called_once_with(30)
 
     @pytest.mark.asyncio
     async def test_select_duration_proceeds_to_availability(self, mock_update_with_query, mock_context):
@@ -121,7 +135,7 @@ class TestDurationSelection:
         mock_context.user_data = {"timezone": "Europe/Moscow", "offset_days": 0}
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await select_duration(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
@@ -137,7 +151,6 @@ class TestDurationSelection:
 
         with patch("app.handlers.booking.settings") as mock_settings:
             error = ValueError("No event type ID configured")
-            mock_settings.get_event_type_id.side_effect = error
             mock_settings.resolve_event_type.side_effect = error
             result = await select_duration(mock_update_with_query, mock_context)
 
@@ -163,7 +176,7 @@ class TestFifthStepAcknowledgement:
         }
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id.return_value = 42
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await booking_handler.acknowledge_fifth_step_duration(
                 mock_update_with_query, mock_context
             )
@@ -193,7 +206,9 @@ class TestFifthStepAcknowledgement:
         }
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id.side_effect = lambda duration: duration
+            mock_settings.resolve_event_type.side_effect = lambda duration: (
+                _resolved_event_type(duration, event_type_id=duration)
+            )
             await booking_handler.acknowledge_fifth_step_duration(
                 mock_update_with_query, mock_context
             )
@@ -283,7 +298,7 @@ class TestDurationLimitAutoSelect:
         }
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id = MagicMock(return_value=42)
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             result = await select_timezone(mock_update_with_query, mock_context)
 
         assert result == BookingState.VIEWING_AVAILABILITY
@@ -305,7 +320,7 @@ class TestDurationLimitAutoSelect:
         mock_context.user_data = {"pending_duration": 120}
 
         with patch("app.handlers.booking.settings") as mock_settings:
-            mock_settings.get_event_type_id.return_value = 42
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
             await select_timezone(mock_update_with_query, mock_context)
 
         assert "pending_duration" not in mock_context.user_data

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -82,6 +82,7 @@ class TestBookingModels:
         request = BookingRequest(
             eventTypeId=123,
             start="2026-01-01T10:00:00Z",
+            lengthInMinutes=120,
             attendee=Attendee(
                 name="Test User",
                 email="test@example.com",
@@ -90,6 +91,7 @@ class TestBookingModels:
             metadata={"telegram_user_id": "12345"},
         )
         assert request.eventTypeId == 123
+        assert request.lengthInMinutes == 120
         assert request.metadata["telegram_user_id"] == "12345"
 
     def test_booking_response_model(self):
@@ -147,6 +149,37 @@ class TestCalComClient:
             assert isinstance(result, AvailabilityResponse)
             assert len(result.slots) == 1
             mock_request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_availability_sends_requested_duration(self, client):
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"status": "success", "data": {"slots": {}}}
+
+            await client.get_availability(
+                event_type_id=123,
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 7),
+                timezone="Europe/Moscow",
+                duration_minutes=120,
+            )
+
+        assert mock_request.call_args.kwargs["params"]["duration"] == 120
+
+    @pytest.mark.asyncio
+    async def test_availability_cache_separates_durations(self, client):
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"status": "success", "data": {"slots": {}}}
+
+            for duration in (60, 120):
+                await client.get_availability(
+                    event_type_id=123,
+                    start_date=date(2026, 1, 1),
+                    end_date=date(2026, 1, 7),
+                    timezone="Europe/Moscow",
+                    duration_minutes=duration,
+                )
+
+        assert mock_request.call_count == 2
 
     @pytest.mark.asyncio
     async def test_get_availability_uses_cache(self, client):

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -94,6 +94,20 @@ class TestBookingModels:
         assert request.lengthInMinutes == 120
         assert request.metadata["telegram_user_id"] == "12345"
 
+    def test_booking_request_allows_no_duration_override(self):
+        request = BookingRequest(
+            eventTypeId=123,
+            start="2026-01-01T10:00:00Z",
+            lengthInMinutes=None,
+            attendee=Attendee(
+                name="Test User",
+                email="test@example.com",
+                timeZone="Europe/Moscow",
+            ),
+        )
+
+        assert request.lengthInMinutes is None
+
     def test_booking_response_model(self):
         """Parse booking response from Cal.com API."""
         data = {
@@ -165,6 +179,21 @@ class TestCalComClient:
             )
 
         assert mock_request.call_args.kwargs["params"]["duration"] == 120
+
+    @pytest.mark.asyncio
+    async def test_get_availability_omits_duration_without_override(self, client):
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = {"status": "success", "data": {"slots": {}}}
+
+            await client.get_availability(
+                event_type_id=123,
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 7),
+                timezone="Europe/Moscow",
+                duration_minutes=None,
+            )
+
+        assert "duration" not in mock_request.call_args.kwargs["params"]
 
     @pytest.mark.asyncio
     async def test_availability_cache_separates_durations(self, client):
@@ -327,6 +356,36 @@ class TestCalComClient:
             assert isinstance(result, BookingResponse)
             assert result.id == 123
             assert result.status == "accepted"
+
+    @pytest.mark.asyncio
+    async def test_create_booking_omits_none_duration_override(self, client):
+        mock_response = {
+            "status": "success",
+            "data": {
+                "id": 123,
+                "uid": "abc-123",
+                "title": "Step work",
+                "start": "2026-01-01T10:00:00.000Z",
+                "end": "2026-01-01T10:30:00.000Z",
+                "status": "accepted",
+            },
+        }
+        request = BookingRequest(
+            eventTypeId=123,
+            start="2026-01-01T10:00:00Z",
+            lengthInMinutes=None,
+            attendee=Attendee(
+                name="Test User",
+                email="test@example.com",
+                timeZone="Europe/Moscow",
+            ),
+        )
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            await client.create_booking(request)
+
+        assert "lengthInMinutes" not in mock_request.call_args.kwargs["json"]
 
     @pytest.mark.asyncio
     async def test_create_booking_clears_cache(self, client):

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -144,6 +144,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             assert isinstance(result, AvailabilityResponse)
@@ -204,6 +205,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             # Second call with same params
@@ -212,6 +214,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             # Only one API call should be made
@@ -236,6 +239,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             await client.get_availability(
@@ -243,6 +247,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 8),  # Different date
                 end_date=date(2026, 1, 14),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             # Two API calls should be made
@@ -269,6 +274,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             # Wait for cache to expire
@@ -279,6 +285,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
 
             # Two API calls should be made after cache expired
@@ -307,6 +314,7 @@ class TestCalComClient:
             request = BookingRequest(
                 eventTypeId=123,
                 start="2026-01-01T10:00:00Z",
+                lengthInMinutes=60,
                 attendee=Attendee(
                     name="Test User",
                     email="test@example.com",
@@ -349,6 +357,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
             assert mock_request.call_count == 1
 
@@ -358,6 +367,7 @@ class TestCalComClient:
                 BookingRequest(
                     eventTypeId=123,
                     start="2026-01-01T10:00:00Z",
+                    lengthInMinutes=60,
                     attendee=Attendee(
                         name="Test",
                         email="test@example.com",
@@ -374,6 +384,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
             assert mock_request.call_count == 3  # Cache was cleared
 
@@ -389,6 +400,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
             assert mock_request.call_count == 1
 
@@ -405,6 +417,7 @@ class TestCalComClient:
                 start_date=date(2026, 1, 1),
                 end_date=date(2026, 1, 7),
                 timezone="Europe/Moscow",
+                duration_minutes=60,
             )
             assert mock_request.call_count == 3
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,7 @@ def test_get_event_type_id_fallback():
     settings = Settings(calcom_event_type_id=99)
     assert settings.get_event_type_id(30) == 99
     assert settings.get_event_type_id(60) == 99
+    assert settings.get_event_type_id(120) == 99
 
 
 def test_get_event_type_id_unknown_duration():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,21 @@ def test_get_event_type_id_with_duration_specific():
     assert settings.get_event_type_id(60) == 60
 
 
+def test_resolve_event_type_omits_duration_for_specific_event():
+    from app.config import Settings
+
+    settings = Settings(
+        calcom_event_type_id=1,
+        calcom_event_type_id_30=30,
+        calcom_event_type_id_60=60,
+    )
+
+    resolved = settings.resolve_event_type(30)
+
+    assert resolved.event_type_id == 30
+    assert resolved.duration_minutes is None
+
+
 def test_get_event_type_id_fallback():
     """Test get_event_type_id falls back to calcom_event_type_id."""
     from app.config import Settings
@@ -52,6 +67,30 @@ def test_get_event_type_id_fallback():
     assert settings.get_event_type_id(30) == 99
     assert settings.get_event_type_id(60) == 99
     assert settings.get_event_type_id(120) == 99
+
+
+def test_resolve_event_type_includes_duration_for_shared_event():
+    from app.config import Settings
+
+    settings = Settings(calcom_event_type_id=99)
+
+    resolved = settings.resolve_event_type(120)
+
+    assert resolved.event_type_id == 99
+    assert resolved.duration_minutes == 120
+
+
+def test_validate_event_type_configuration_requires_120_minute_mapping():
+    from app.config import Settings
+
+    settings = Settings(
+        calcom_event_type_id=None,
+        calcom_event_type_id_30=30,
+        calcom_event_type_id_60=60,
+    )
+
+    with pytest.raises(ValueError, match="120-minute"):
+        settings.validate_event_type_configuration()
 
 
 def test_get_event_type_id_unknown_duration():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for configuration loading."""
 
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -91,6 +92,20 @@ def test_validate_event_type_configuration_requires_120_minute_mapping():
 
     with pytest.raises(ValueError, match="120-minute"):
         settings.validate_event_type_configuration()
+
+
+def test_validate_event_type_configuration_uses_supported_duration_constant():
+    from app.config import Settings
+
+    settings = Settings(calcom_event_type_id=99)
+
+    with (
+        patch("app.config.SUPPORTED_BOOKING_DURATIONS", (45,)),
+        patch.object(Settings, "resolve_event_type") as mock_resolve_event_type,
+    ):
+        settings.validate_event_type_configuration()
+
+    mock_resolve_event_type.assert_called_once_with(45)
 
 
 def test_get_event_type_id_unknown_duration():

--- a/tests/test_duration_limit.py
+++ b/tests/test_duration_limit.py
@@ -128,6 +128,16 @@ class TestSetlimitCommand:
         assert duration_limit_service.get_limit(777) == 60
 
     @pytest.mark.asyncio
+    async def test_sets_120_minute_limit(
+        self, mock_update, mock_context, duration_limit_service
+    ):
+        mock_context.args = ["555", "120"]
+
+        await setlimit_command(mock_update, mock_context)
+
+        assert duration_limit_service.get_limit(555) == 120
+
+    @pytest.mark.asyncio
     async def test_rejects_invalid_duration(self, mock_update, mock_context):
         mock_context.args = ["555", "45"]
         await setlimit_command(mock_update, mock_context)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,11 +38,16 @@ class TestErrorHandler:
 class TestMain:
     """Tests for main application wiring."""
 
+    @patch("app.main.settings.validate_event_type_configuration")
     @patch("app.main.Application")
     @patch("app.main.run_migrations")
     @patch("app.main.setup_logging")
     def test_registers_error_handler_and_starts_polling(
-        self, mock_setup_logging, mock_run_migrations, mock_application
+        self,
+        mock_setup_logging,
+        mock_run_migrations,
+        mock_application,
+        mock_validate_event_types,
     ):
         app_instance = MagicMock()
         mock_application.builder.return_value.token.return_value.build.return_value = app_instance
@@ -50,6 +55,7 @@ class TestMain:
         main()
 
         mock_setup_logging.assert_called_once()
+        mock_validate_event_types.assert_called_once_with()
         mock_run_migrations.assert_called_once()
         app_instance.add_error_handler.assert_called_once_with(error_handler)
         app_instance.run_polling.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,26 @@ class TestErrorHandler:
 class TestMain:
     """Tests for main application wiring."""
 
-    @patch("app.main.settings.validate_event_type_configuration")
+    @patch("app.config.Settings.validate_event_type_configuration")
+    @patch("app.main.run_migrations")
+    @patch("app.main.setup_logging")
+    def test_invalid_event_type_config_fails_before_migrations(
+        self,
+        mock_setup_logging,
+        mock_run_migrations,
+        mock_validate_event_types,
+    ):
+        mock_validate_event_types.side_effect = ValueError(
+            "No event type ID configured for 120-minute duration"
+        )
+
+        with pytest.raises(ValueError, match="120-minute"):
+            main()
+
+        mock_setup_logging.assert_called_once_with()
+        mock_run_migrations.assert_not_called()
+
+    @patch("app.config.Settings.validate_event_type_configuration")
     @patch("app.main.Application")
     @patch("app.main.run_migrations")
     @patch("app.main.setup_logging")


### PR DESCRIPTION
## Summary

- add native 30, 60, and 120-minute Cal.com availability and booking durations
- require a Russian fifth-step acknowledgement before showing 120-minute slots
- preserve split fixed-duration Cal.com event types by omitting unsupported duration overrides
- centralize supported durations across booking, startup validation, and admin limits
- validate all supported duration mappings at startup and recover safely from stale callbacks
- keep availability caches separated by duration and preserve live duration-limit enforcement
- allow admins to assign 120-minute duration limits

## Why

The configured Cal.com event type now supports multiple native durations, including 120 minutes. A two-hour session can therefore be represented by one Cal.com booking instead of coordinating two consecutive one-hour bookings.

## Validation

- `uv sync --frozen`
- `uv run ruff check .`
- `uv run pytest tests/ -q` (`233 passed`)
- `docker build -t telecalbot:ci .`
- Docker application-import and migration smoke tests
- live read-only Cal.com smoke: event type `2442700`, duration `120`, `7` available slots

Closes #63
