### PR TITLE
Fix Cal.com optional-email bookings

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,10 @@ CALCOM_API_KEY=
 # Check Cal.com API docs for the latest version
 CAL_API_VERSION=2024-08-13
 
+# Dedicated deliverable mailbox used when a user skips their personal email (optional)
+# Required for private bookings; use a privacy-specific operational inbox
+CALCOM_PRIVACY_EMAIL=
+
 # Admin Configuration (Required)
 # Your Telegram user ID for admin access and approval notifications
 ADMIN_TELEGRAM_ID=

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Required environment variables:
 - `CALCOM_API_KEY` - Your Cal.com API key
 - `ADMIN_TELEGRAM_ID` - Your Telegram user ID for admin access
 
+Optional environment variables:
+- `CALCOM_PRIVACY_EMAIL` - A dedicated deliverable mailbox Cal.com can use when a user chooses not to provide a personal email. If unset or rejected by Cal.com, the bot explains that private booking is temporarily unavailable and offers the user a voluntary email path.
+
 See `.env.sample` for a complete list of configuration options.
 
 ## Development Status

--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     # Cal.com API Configuration (Required)
     calcom_api_key: str
     cal_api_version: str = "2024-08-13"
+    calcom_privacy_email: str | None = None
 
     # Admin Configuration (Required)
     admin_telegram_id: int

--- a/app/database/migrations.py
+++ b/app/database/migrations.py
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS duration_limits (
 -- Persisted bookings for /cancel_booking flow
 CREATE TABLE IF NOT EXISTS bookings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    internal_ref TEXT,
     telegram_id INTEGER NOT NULL,
     calcom_booking_id INTEGER NOT NULL,
     calcom_booking_uid TEXT NOT NULL,
@@ -71,6 +72,7 @@ def run_migrations(db: Database) -> None:
     """Run any pending database migrations."""
     initialize_schema(db)
     _migrate_bookings_time_columns(db)
+    _ensure_bookings_internal_ref(db)
     _ensure_bookings_indexes(db)
 
 
@@ -120,5 +122,27 @@ def _ensure_bookings_indexes(db: Database) -> None:
         """
         CREATE INDEX IF NOT EXISTS idx_bookings_user_status_start
         ON bookings(telegram_id, status, start_at)
+        """
+    )
+
+
+def _ensure_bookings_internal_ref(db: Database) -> None:
+    """Add private booking references to existing databases."""
+    table_exists = db.execute_one(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='bookings'"
+    )
+    if table_exists is None:
+        return
+
+    columns = {row["name"] for row in db.execute("PRAGMA table_info(bookings)")}
+    if "internal_ref" not in columns:
+        logger.info("Adding internal_ref column to bookings table")
+        db.execute_write("ALTER TABLE bookings ADD COLUMN internal_ref TEXT")
+
+    db.execute_write(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_bookings_internal_ref
+        ON bookings(internal_ref)
+        WHERE internal_ref IS NOT NULL
         """
     )

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -37,6 +37,7 @@ class StoredBooking(BaseModel):
     """Booking record persisted for cancellation lookup."""
 
     id: int
+    internal_ref: str | None = None
     telegram_id: int
     calcom_booking_id: int
     calcom_booking_uid: str

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -1,6 +1,7 @@
 """Booking conversation handler for multi-step appointment booking."""
 
 import logging
+import secrets
 from datetime import date, datetime, timedelta, timezone
 from enum import IntEnum, auto
 
@@ -83,6 +84,24 @@ BOOKING_REMINDER_JOB_PREFIX = "booking_timeout_reminder:"
 BOOKING_TIMEOUT_REMINDER_TEXT = (
     "Напоминание: сессия записи скоро истечет из-за неактивности.\n"
     "Пожалуйста, завершите запись или начните заново командой /book."
+)
+BOOKING_SCOPED_USER_DATA_KEYS = frozenset(
+    {
+        "timezone",
+        "offset_days",
+        "duration",
+        "pending_duration",
+        "selected_date",
+        "selected_time",
+        "name",
+        "email",
+        "internal_ref",
+    }
+)
+EMAIL_DOMAIN_CANNOT_RECEIVE_MAIL = "email_domain_cannot_receive_mail"
+PRIVACY_EMAIL_UNAVAILABLE_TEXT = (
+    "Запись без личного email временно недоступна. "
+    "Вы можете указать email сейчас или попробовать позже."
 )
 
 
@@ -167,6 +186,47 @@ def _apply_current_duration_limit(
 
 def _booking_reminder_job_name(user_id: int) -> str:
     return f"{BOOKING_REMINDER_JOB_PREFIX}{user_id}"
+
+
+def _clear_booking_scoped_state(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Remove only transient values owned by the booking conversation."""
+    for key in BOOKING_SCOPED_USER_DATA_KEYS:
+        context.user_data.pop(key, None)
+
+
+def _privacy_email() -> str | None:
+    configured_email = getattr(settings, "calcom_privacy_email", None)
+    if not isinstance(configured_email, str):
+        return None
+    configured_email = configured_email.strip()
+    return configured_email or None
+
+
+def _booking_reference(data: dict) -> str:
+    existing_reference = data.get("internal_ref")
+    if isinstance(existing_reference, str) and existing_reference.startswith("tbk_"):
+        return existing_reference
+
+    reference = f"tbk_{secrets.token_hex(8)}"
+    data["internal_ref"] = reference
+    return reference
+
+
+async def _show_privacy_email_unavailable(query) -> int:
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Указать email", callback_data="email_yes"),
+                InlineKeyboardButton("Отмена", callback_data="cancel"),
+            ]
+        ]
+    )
+    await _safe_edit_message_text(
+        query,
+        PRIVACY_EMAIL_UNAVAILABLE_TEXT,
+        reply_markup=keyboard,
+    )
+    return BookingState.EMAIL_DECISION
 
 
 def _coerce_positive_int(value, default: int) -> int:
@@ -266,6 +326,7 @@ async def _send_booking_timeout_reminder(context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Start the booking conversation with timezone selection."""
+    _clear_booking_scoped_state(context)
     if not _is_whitelisted(update, context):
         _cancel_booking_timeout_reminder(context, update.effective_user.id)
         await _deny_booking_access(update)
@@ -682,7 +743,13 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     data = context.user_data
     calcom_client: CalComClient = context.bot_data["calcom_client"]
-    email = data.get("email") or f"telegram-{update.effective_user.id}@telecalbot.local"
+    personal_email = data.get("email")
+    email = personal_email or _privacy_email()
+    if email is None:
+        logger.error("Cal.com privacy email is not configured")
+        return await _show_privacy_email_unavailable(query)
+
+    internal_ref = _booking_reference(data)
     duration = _apply_current_duration_limit(
         context,
         update.effective_user.id,
@@ -712,7 +779,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                     timeZone=data["timezone"],
                 ),
                 metadata={
-                    "telegram_user_id": str(update.effective_user.id),
+                    "telecalbot_booking_ref": internal_ref,
                     "booked_via": "telegram_bot",
                 },
             )
@@ -720,7 +787,11 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         booking_service: BookingService | None = context.bot_data.get("booking_service")
         if booking_service is not None:
             try:
-                booking_service.save_booking(update.effective_user.id, booking)
+                booking_service.save_booking(
+                    update.effective_user.id,
+                    booking,
+                    internal_ref=internal_ref,
+                )
             except Exception:
                 logger.exception(
                     "Failed to persist booking for user_id=%s booking_id=%s",
@@ -743,7 +814,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         duration_str = _format_duration(booking)
         email_note = (
-            f"\nПисьмо с подтверждением отправлено на {email}." if data.get("email") else ""
+            f"\nПисьмо с подтверждением отправлено на {email}." if personal_email else ""
         )
 
         await _safe_edit_message_text(
@@ -759,11 +830,22 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     except CalComAPIError as e:
         logger.warning(
-            "Booking create failed for user_id=%s status=%s message=%s",
+            "Booking create failed for user_id=%s status=%s code=%s message=%s",
             update.effective_user.id,
             e.status_code,
+            e.code,
             e.message,
         )
+        if e.code == EMAIL_DOMAIN_CANNOT_RECEIVE_MAIL:
+            if not personal_email:
+                return await _show_privacy_email_unavailable(query)
+
+            data.pop("email", None)
+            await _safe_edit_message_text(
+                query,
+                "Cal.com не принимает этот email. Укажите другой адрес или отмените запись командой /cancel.",
+            )
+            return BookingState.ENTERING_EMAIL
         if e.status_code == 409:
             error_msg = "Это время уже занято. Пожалуйста, выберите другое время."
         else:
@@ -1222,6 +1304,7 @@ def create_booking_conversation_handler() -> ConversationHandler:
             ConversationHandler.TIMEOUT: [TypeHandler(Update, booking_timeout)],
         },
         fallbacks=[CommandHandler("cancel", cancel)],
+        allow_reentry=True,
         conversation_timeout=timedelta(seconds=settings.booking_conversation_timeout_seconds),
     )
 

--- a/app/services/booking_service.py
+++ b/app/services/booking_service.py
@@ -18,12 +18,18 @@ class BookingService:
     def __init__(self, db: Database):
         self.db = db
 
-    def save_booking(self, telegram_id: int, booking: BookingResponse) -> int:
+    def save_booking(
+        self,
+        telegram_id: int,
+        booking: BookingResponse,
+        internal_ref: str | None = None,
+    ) -> int:
         """Insert or refresh an active booking record for a user."""
         now = datetime.now(timezone.utc).isoformat()
         self.db.execute_write(
             """
             INSERT INTO bookings (
+                internal_ref,
                 telegram_id,
                 calcom_booking_id,
                 calcom_booking_uid,
@@ -34,8 +40,9 @@ class BookingService:
                 created_at,
                 cancelled_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, 'active', ?, NULL)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, NULL)
             ON CONFLICT(telegram_id, calcom_booking_id) DO UPDATE SET
+                internal_ref = COALESCE(excluded.internal_ref, bookings.internal_ref),
                 calcom_booking_uid = excluded.calcom_booking_uid,
                 title = excluded.title,
                 start_at = excluded.start_at,
@@ -44,6 +51,7 @@ class BookingService:
                 cancelled_at = NULL
             """,
             (
+                internal_ref,
                 telegram_id,
                 booking.id,
                 booking.uid,
@@ -62,6 +70,16 @@ class BookingService:
             (telegram_id, booking.id),
         )
         return row["id"]
+
+    def get_booking_by_internal_ref(self, internal_ref: str) -> StoredBooking | None:
+        """Resolve an opaque Cal.com reference to its local booking owner."""
+        row = self.db.execute_one(
+            "SELECT * FROM bookings WHERE internal_ref = ?",
+            (internal_ref,),
+        )
+        if row is None:
+            return None
+        return self._row_to_booking(row)
 
     def list_upcoming_bookings(self, telegram_id: int) -> list[StoredBooking]:
         """Return active bookings that haven't ended yet."""
@@ -109,6 +127,7 @@ class BookingService:
     def _row_to_booking(row) -> StoredBooking:
         return StoredBooking(
             id=row["id"],
+            internal_ref=row["internal_ref"],
             telegram_id=row["telegram_id"],
             calcom_booking_id=row["calcom_booking_id"],
             calcom_booking_uid=row["calcom_booking_uid"],

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 import time
 from datetime import date
 from typing import Any
@@ -15,14 +16,42 @@ logger = logging.getLogger(__name__)
 class CalComAPIError(Exception):
     """Exception for Cal.com API errors with user-friendly messages."""
 
-    def __init__(self, status_code: int, message: str):
+    def __init__(self, status_code: int, message: str, code: str | None = None):
         self.status_code = status_code
         self.message = message
+        self.code = code
         super().__init__(f"Cal.com API error {status_code}: {message}")
 
     def user_message(self) -> str:
         """Return user-friendly error message."""
         return "Something went wrong. Please try again."
+
+
+def _extract_error_code(response: httpx.Response) -> str | None:
+    """Extract Cal.com's machine-readable error code from a failed response."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    code = payload.get("code")
+    if isinstance(code, str) and code:
+        return code
+
+    message = payload.get("message")
+    if isinstance(message, str) and re.fullmatch(r"[a-z][a-z0-9_]+", message):
+        return message
+
+    error = payload.get("error")
+    if isinstance(error, dict):
+        nested_code = error.get("code")
+        if isinstance(nested_code, str) and nested_code:
+            return nested_code
+
+    return None
 
 
 class TimeSlot(BaseModel):
@@ -231,9 +260,19 @@ class CalComClient:
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code
                 message = e.response.text
-                logger.error("Cal.com API error %d: %s", status_code, message)
+                error_code = _extract_error_code(e.response)
+                logger.error(
+                    "Cal.com API error %d code=%s: %s",
+                    status_code,
+                    error_code,
+                    message,
+                )
 
-                last_error = CalComAPIError(status_code=status_code, message=message)
+                last_error = CalComAPIError(
+                    status_code=status_code,
+                    message=message,
+                    code=error_code,
+                )
                 should_retry = status_code in self.RETRYABLE_STATUS_CODES
             except httpx.RequestError as e:
                 message = str(e)

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -11,6 +11,7 @@ from app.config import ResolvedEventType
 from app.constants import RUSSIAN_TIMEZONES
 from app.handlers.booking import (
     BookingState,
+    _booking_reference,
     _format_duration,
     book_command,
     booking_timeout,
@@ -140,6 +141,15 @@ def availability_response():
 # ---------------------------------------------------------------------------
 # Helper function tests
 # ---------------------------------------------------------------------------
+
+
+def test_booking_references_are_unique_per_booking_attempt():
+    first_reference = _booking_reference({})
+    second_reference = _booking_reference({})
+
+    assert first_reference.startswith("tbk_")
+    assert second_reference.startswith("tbk_")
+    assert first_reference != second_reference
 
 
 class TestFormatDateHeader:
@@ -872,7 +882,9 @@ class TestConfirmBooking:
             await confirm_booking(mock_update_with_query, mock_context)
 
         mock_context.bot_data["booking_service"].save_booking.assert_called_once_with(
-            12345, booking_response
+            12345,
+            booking_response,
+            internal_ref=mock_context.user_data["internal_ref"],
         )
 
     @pytest.mark.asyncio

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -738,7 +738,9 @@ class TestConfirmBooking:
         assert request.attendee.name == "Alice"
         assert request.attendee.email == "alice@example.com"
         assert request.attendee.timeZone == "Europe/Moscow"
-        assert "telegram_user_id" in request.metadata
+        assert request.metadata["telecalbot_booking_ref"].startswith("tbk_")
+        assert "telegram_user_id" not in request.metadata
+        assert "12345" not in str(request.metadata)
 
     @pytest.mark.asyncio
     async def test_fixed_duration_event_omits_booking_length_override(
@@ -874,7 +876,7 @@ class TestConfirmBooking:
         )
 
     @pytest.mark.asyncio
-    async def test_uses_placeholder_email_when_none(
+    async def test_uses_configured_privacy_email_and_opaque_reference_when_none(
         self,
         mock_update_with_query,
         mock_context,
@@ -894,11 +896,84 @@ class TestConfirmBooking:
 
         with patch("app.handlers.booking.settings") as mock_settings:
             mock_settings.resolve_event_type.side_effect = _resolved_event_type
+            mock_settings.calcom_privacy_email = "private-bookings@example.net"
             await confirm_booking(mock_update_with_query, mock_context)
 
         request = mock_calcom_client.create_booking.call_args[0][0]
-        assert "12345" in request.attendee.email
-        assert "telecalbot.local" in request.attendee.email
+        assert request.attendee.email == "private-bookings@example.net"
+        assert "telecalbot.local" not in request.attendee.email
+        assert request.metadata["telecalbot_booking_ref"].startswith("tbk_")
+        assert "12345" not in str(request.metadata)
+        mock_context.bot_data["booking_service"].save_booking.assert_called_once_with(
+            12345,
+            booking_response,
+            internal_ref=request.metadata["telecalbot_booking_ref"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_privacy_email_offers_personal_email_without_calling_calcom(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {
+            "name": "Alice",
+            "email": None,
+            "selected_date": "2026-01-06",
+            "selected_time": "2026-01-06T10:00:00.000+03:00",
+            "timezone": "Europe/Moscow",
+        }
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
+            mock_settings.calcom_privacy_email = None
+            result = await confirm_booking(mock_update_with_query, mock_context)
+
+        assert result == BookingState.EMAIL_DECISION
+        mock_calcom_client.create_booking.assert_not_called()
+        message = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
+        assert "без личного email временно недоступна" in message
+        keyboard = mock_update_with_query.callback_query.edit_message_text.call_args.kwargs[
+            "reply_markup"
+        ]
+        callbacks = {
+            button.callback_data
+            for row in keyboard.inline_keyboard
+            for button in row
+        }
+        assert callbacks == {"email_yes", "cancel"}
+
+    @pytest.mark.asyncio
+    async def test_rejected_privacy_email_does_not_strand_booking_flow(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {
+            "name": "Alice",
+            "email": None,
+            "selected_date": "2026-01-06",
+            "selected_time": "2026-01-06T10:00:00.000+03:00",
+            "timezone": "Europe/Moscow",
+        }
+        mock_calcom_client.create_booking.side_effect = CalComAPIError(
+            400,
+            "captured response",
+            code="email_domain_cannot_receive_mail",
+        )
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
+            mock_settings.calcom_privacy_email = "private-bookings@example.net"
+            result = await confirm_booking(mock_update_with_query, mock_context)
+
+        assert result == BookingState.EMAIL_DECISION
+        message = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
+        assert "без личного email временно недоступна" in message
 
     @pytest.mark.asyncio
     async def test_handles_409_conflict(
@@ -1119,6 +1194,36 @@ class TestBookingTimeoutReminderLifecycle:
         assert call_kwargs["when"] == 780
         assert call_kwargs["data"] == {"user_id": 12345}
         assert call_kwargs["name"] == "booking_timeout_reminder:12345"
+
+    @pytest.mark.asyncio
+    async def test_book_command_restart_clears_stale_state_and_replaces_reminder(
+        self, mock_update, mock_context
+    ):
+        mock_context.user_data = {
+            "timezone": "Europe/Moscow",
+            "offset_days": 10,
+            "duration": 60,
+            "pending_duration": 120,
+            "selected_date": "2026-01-06",
+            "selected_time": "2026-01-06T10:00:00.000+03:00",
+            "name": "Stale name",
+            "email": "stale@example.com",
+            "internal_ref": "tbk_stale",
+            "unrelated": "keep",
+        }
+        previous_reminder_job = MagicMock()
+        mock_context.job_queue = MagicMock()
+        mock_context.job_queue.get_jobs_by_name.return_value = [previous_reminder_job]
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.booking_conversation_timeout_seconds = 900
+            mock_settings.booking_conversation_reminder_seconds_before_timeout = 120
+            result = await book_command(mock_update, mock_context)
+
+        assert result == BookingState.SELECTING_TIMEZONE
+        assert mock_context.user_data == {"unrelated": "keep"}
+        previous_reminder_job.schedule_removal.assert_called_once()
+        mock_context.job_queue.run_once.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_select_slot_refreshes_existing_timeout_reminder(
@@ -1382,6 +1487,11 @@ class TestCreateBookingHandler:
         assert ConversationHandler.TIMEOUT in handler.states
         timeout_handlers = handler.states[ConversationHandler.TIMEOUT]
         assert len(timeout_handlers) == 1
+
+    def test_allows_book_command_to_restart_active_conversation(self):
+        handler = create_booking_conversation_handler()
+
+        assert handler.allow_reentry is True
 
 
 class TestLoadMoreDates:

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -988,6 +988,36 @@ class TestConfirmBooking:
         assert "без личного email временно недоступна" in message
 
     @pytest.mark.asyncio
+    async def test_rejected_personal_email_returns_to_email_entry(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {
+            "name": "Alice",
+            "email": "rejected@example.com",
+            "selected_date": "2026-01-06",
+            "selected_time": "2026-01-06T10:00:00.000+03:00",
+            "timezone": "Europe/Moscow",
+        }
+        mock_calcom_client.create_booking.side_effect = CalComAPIError(
+            400,
+            "captured response",
+            code="email_domain_cannot_receive_mail",
+        )
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
+            result = await confirm_booking(mock_update_with_query, mock_context)
+
+        assert result == BookingState.ENTERING_EMAIL
+        assert "email" not in mock_context.user_data
+        message = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
+        assert "не принимает этот email" in message
+
+    @pytest.mark.asyncio
     async def test_handles_409_conflict(
         self,
         mock_update_with_query,

--- a/tests/test_booking_service.py
+++ b/tests/test_booking_service.py
@@ -32,13 +32,29 @@ def test_save_and_list_upcoming_bookings(temp_db_path):
     upcoming = _make_booking_response(1001, now + timedelta(hours=1), now + timedelta(hours=2))
     past = _make_booking_response(1002, now - timedelta(hours=3), now - timedelta(hours=2))
 
-    service.save_booking(telegram_id=12345, booking=upcoming)
-    service.save_booking(telegram_id=12345, booking=past)
+    service.save_booking(telegram_id=12345, booking=upcoming, internal_ref="tbk_upcoming")
+    service.save_booking(telegram_id=12345, booking=past, internal_ref="tbk_past")
 
     results = service.list_upcoming_bookings(12345)
 
     assert len(results) == 1
     assert results[0].calcom_booking_id == 1001
+    assert results[0].internal_ref == "tbk_upcoming"
+
+
+def test_get_booking_by_internal_ref_maps_to_telegram_user(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    service = BookingService(db)
+
+    now = datetime.now(timezone.utc)
+    booking = _make_booking_response(1003, now + timedelta(hours=1), now + timedelta(hours=2))
+    service.save_booking(telegram_id=12345, booking=booking, internal_ref="tbk_opaque")
+
+    result = service.get_booking_by_internal_ref("tbk_opaque")
+
+    assert result is not None
+    assert result.telegram_id == 12345
 
 
 def test_get_booking_for_user_enforces_ownership(temp_db_path):

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -97,11 +97,11 @@ class TestBookingModels:
                 email="test@example.com",
                 timeZone="Europe/Moscow",
             ),
-            metadata={"telegram_user_id": "12345"},
+            metadata={"telecalbot_booking_ref": "tbk_test"},
         )
         assert request.eventTypeId == 123
         assert request.lengthInMinutes == 120
-        assert request.metadata["telegram_user_id"] == "12345"
+        assert request.metadata["telecalbot_booking_ref"] == "tbk_test"
 
     def test_booking_request_allows_no_duration_override(self):
         request = BookingRequest(

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -27,6 +27,15 @@ class TestCalComAPIError:
             error = CalComAPIError(status_code=status, message="Some error")
             assert error.user_message() == "Something went wrong. Please try again."
 
+    def test_retains_machine_readable_error_code(self):
+        error = CalComAPIError(
+            status_code=400,
+            message="email_domain_cannot_receive_mail",
+            code="email_domain_cannot_receive_mail",
+        )
+
+        assert error.code == "email_domain_cannot_receive_mail"
+
 
 class TestTimeSlotModel:
     """Test TimeSlot Pydantic model."""
@@ -501,6 +510,41 @@ class TestCalComClientRetry:
             request=request,
             response=response,
         )
+
+    @pytest.mark.asyncio
+    async def test_parses_captured_email_deliverability_error_code(self, client):
+        response = httpx.Response(
+            400,
+            request=httpx.Request("POST", "https://api.cal.com/v2/bookings"),
+            json={
+                "statusCode": 400,
+                "message": "email_domain_cannot_receive_mail",
+                "status": "error",
+                "timestamp": "2026-07-16T05:58:04.210Z",
+                "path": "/v2/bookings",
+                "error": {
+                    "code": "HttpError",
+                    "message": "This email address cannot receive mail. Please use a valid email.",
+                    "details": {
+                        "message": "This email address cannot receive mail. Please use a valid email.",
+                        "error": "Bad Request",
+                        "statusCode": 400,
+                    },
+                },
+            },
+        )
+
+        with patch.object(
+            client._client,
+            "request",
+            new_callable=AsyncMock,
+            return_value=response,
+        ):
+            with pytest.raises(CalComAPIError) as exc_info:
+                await client._request("POST", "/bookings", json={})
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.code == "email_domain_cannot_receive_mail"
 
     @pytest.mark.asyncio
     async def test_retries_retryable_status_then_succeeds(self, client):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,15 @@ def test_config_defaults():
     assert settings.log_level == "INFO"
     assert settings.booking_conversation_timeout_seconds == 900
     assert settings.booking_conversation_reminder_seconds_before_timeout == 120
+    assert settings.calcom_privacy_email is None
+
+
+def test_config_accepts_privacy_email():
+    from app.config import Settings
+
+    settings = Settings(calcom_privacy_email="private-bookings@example.net")
+
+    assert settings.calcom_privacy_email == "private-bookings@example.net"
 
 
 def test_get_event_type_id_with_duration_specific():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -27,6 +27,11 @@ def test_schema_initialization(temp_db_path):
     assert "user_preferences" in table_names
     assert "bookings" in table_names
 
+    booking_columns = {
+        row["name"] for row in db.execute("PRAGMA table_info(bookings)")
+    }
+    assert "internal_ref" in booking_columns
+
 
 def test_whitelist_insert_and_query(temp_db_path):
     """Test inserting and querying whitelist entries."""
@@ -131,3 +136,4 @@ def test_migrates_bookings_start_end_columns(temp_db_path):
     row = db.execute_one("SELECT start_at, end_at FROM bookings WHERE telegram_id = ?", (123,))
     assert row["start_at"] == "2026-01-01T10:00:00Z"
     assert row["end_at"] == "2026-01-01T11:00:00Z"
+    assert "internal_ref" in columns


### PR DESCRIPTION
## Summary

- replace the rejected `@telecalbot.local` placeholder with an explicit `CALCOM_PRIVACY_EMAIL` setting while keeping personal email optional
- parse Cal.com machine-readable error codes and give users a recoverable path when private booking is unavailable or the address is rejected
- replace raw Telegram identifiers in Cal.com payloads with random per-booking `tbk_` references persisted only in Telecalbot's database
- make `/book` restart an active booking conversation after clearing stale booking state and replacing its timeout reminder

## Root cause

Cal.com now rejects the synthetic `@telecalbot.local` attendee address with `email_domain_cannot_receive_mail`. The active conversation then remained in the availability state, where `/book` was ignored because re-entry was disabled.

## Validation

- red regression checkpoint: `14 failed, 134 passed`
- `uv sync --frozen`
- `uv run ruff check .`
- `uv run pytest tests/ -q` (`242 passed`, 5 existing PTB warnings)

## Deployment prerequisite

Configure the explicitly selected dedicated, deliverable mailbox as `CALCOM_PRIVACY_EMAIL`, then run a real Cal.com no-personal-email booking smoke test before deployment. This PR does not choose or create an external mailbox.
