### PR TITLE
Add explicitly consented booking profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Cal.com is blocked in some regions (like Russia), preventing users from accessin
 
 - **Button-Driven Interface**: No command memorization required
 - **Timezone Support**: Displays available times in user's timezone (with special support for Russian timezones)
+- **Consent-Based Booking Profile**: Remembers name, timezone, or email behavior only after an explicit per-field opt-in
 - **Access Control**: Whitelist-based system to manage approved users
 - **Google Calendar Sync**: Bookings automatically sync through Cal.com's integration
 - **Request-Based Approval**: Admin receives notifications when new users request access
@@ -79,6 +80,19 @@ Delivery mode:
 - `TELEGRAM_WEBHOOK_SECRET_TOKEN` is required in webhook mode and rejects forged update payloads.
 
 See `.env.sample` for a complete list of configuration options.
+
+## Remembered Booking Data
+
+By default, the bot asks for booking details again and keeps them only for the current booking. Before confirmation, users can explicitly choose which fields to remember for future bookings:
+
+- preferred booking name;
+- timezone;
+- personal email, with separate consent;
+- preference to book without a personal email.
+
+The `/privacy` command displays remembered values (with email masked), changes or forgets individual fields, and deletes the complete remembered profile. It remains available after whitelist access is removed. Deleting the profile does not cancel active bookings or change Telegram access records.
+
+The profile migration intentionally clears timezones saved automatically by older versions. Existing users are asked again and can opt in under the new consent flow.
 
 ## Deployment
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,6 +1,8 @@
 """Constants used throughout the application."""
 
 SUPPORTED_BOOKING_DURATIONS = (30, 60, 120)
+MAX_NAME_LENGTH = 100
+MAX_EMAIL_LENGTH = 254
 
 # Russian timezones sorted by UTC offset
 RUSSIAN_TIMEZONES = [

--- a/app/constants.py
+++ b/app/constants.py
@@ -17,6 +17,10 @@ RUSSIAN_TIMEZONES = [
     ("Asia/Kamchatka", "Камчатка (UTC+12)"),
 ]
 
+SUPPORTED_TIMEZONE_IDS = frozenset(
+    timezone_id for timezone_id, _ in RUSSIAN_TIMEZONES
+)
+
 # Default timezone
 DEFAULT_TIMEZONE = "Europe/Moscow"
 

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -2,7 +2,12 @@
 
 from app.database.connection import Database, db
 from app.database.migrations import run_migrations
-from app.database.models import AccessRequest, UserPreference, WhitelistEntry
+from app.database.models import (
+    AccessRequest,
+    UserPreference,
+    UserProfile,
+    WhitelistEntry,
+)
 
 __all__ = [
     "Database",
@@ -11,4 +16,5 @@ __all__ = [
     "WhitelistEntry",
     "AccessRequest",
     "UserPreference",
+    "UserProfile",
 ]

--- a/app/database/migrations.py
+++ b/app/database/migrations.py
@@ -30,6 +30,11 @@ USER_PREFERENCES_COLUMNS = {
     "email",
     "updated_at",
 }
+LEGACY_USER_PREFERENCES_COLUMNS = {
+    "telegram_id",
+    "timezone",
+    "updated_at",
+}
 
 SCHEMA = f"""
 -- Whitelist of approved users
@@ -104,6 +109,12 @@ def _migrate_user_preferences_profile(db: Database) -> None:
     columns = {row["name"] for row in table_info}
     if columns == USER_PREFERENCES_COLUMNS:
         return
+    if columns != LEGACY_USER_PREFERENCES_COLUMNS:
+        message = (
+            "Unexpected user_preferences schema; refusing to replace existing data"
+        )
+        logger.error("%s columns=%s", message, ",".join(sorted(columns)))
+        raise RuntimeError(message)
 
     logger.info(
         "Resetting legacy user preferences while migrating to explicit profile consent"

--- a/app/database/migrations.py
+++ b/app/database/migrations.py
@@ -6,7 +6,32 @@ from app.database.connection import Database
 
 logger = logging.getLogger(__name__)
 
-SCHEMA = """
+USER_PREFERENCES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS user_preferences (
+    telegram_id INTEGER PRIMARY KEY,
+    preferred_name TEXT,
+    timezone TEXT,
+    email_mode TEXT NOT NULL DEFAULT 'ask'
+        CHECK (email_mode IN ('ask', 'private', 'saved')),
+    email TEXT,
+    updated_at TEXT NOT NULL,
+    CHECK (
+        (email_mode = 'saved' AND email IS NOT NULL AND trim(email) <> '')
+        OR (email_mode IN ('ask', 'private') AND email IS NULL)
+    )
+);
+"""
+
+USER_PREFERENCES_COLUMNS = {
+    "telegram_id",
+    "preferred_name",
+    "timezone",
+    "email_mode",
+    "email",
+    "updated_at",
+}
+
+SCHEMA = f"""
 -- Whitelist of approved users
 CREATE TABLE IF NOT EXISTS whitelist (
     telegram_id INTEGER PRIMARY KEY,
@@ -25,12 +50,8 @@ CREATE TABLE IF NOT EXISTS access_requests (
     status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected'))
 );
 
--- User preferences (timezone, etc.)
-CREATE TABLE IF NOT EXISTS user_preferences (
-    telegram_id INTEGER PRIMARY KEY,
-    timezone TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-);
+-- Explicitly consented booking profile preferences
+{USER_PREFERENCES_SCHEMA}
 
 -- Duration limits per user (admin-managed)
 CREATE TABLE IF NOT EXISTS duration_limits (
@@ -71,9 +92,26 @@ def initialize_schema(db: Database) -> None:
 def run_migrations(db: Database) -> None:
     """Run any pending database migrations."""
     initialize_schema(db)
+    _migrate_user_preferences_profile(db)
     _migrate_bookings_time_columns(db)
     _ensure_bookings_internal_ref(db)
     _ensure_bookings_indexes(db)
+
+
+def _migrate_user_preferences_profile(db: Database) -> None:
+    """Replace the legacy auto-saved timezone table with consented profile fields."""
+    table_info = db.execute("PRAGMA table_info(user_preferences)")
+    columns = {row["name"] for row in table_info}
+    if columns == USER_PREFERENCES_COLUMNS:
+        return
+
+    logger.info(
+        "Resetting legacy user preferences while migrating to explicit profile consent"
+    )
+    with db.get_connection() as conn:
+        conn.execute("ALTER TABLE user_preferences RENAME TO user_preferences_legacy")
+        conn.executescript(USER_PREFERENCES_SCHEMA)
+        conn.execute("DROP TABLE user_preferences_legacy")
 
 
 def _migrate_bookings_time_columns(db: Database) -> None:

--- a/app/database/migrations.py
+++ b/app/database/migrations.py
@@ -110,7 +110,7 @@ def _migrate_user_preferences_profile(db: Database) -> None:
     )
     with db.get_connection() as conn:
         conn.execute("ALTER TABLE user_preferences RENAME TO user_preferences_legacy")
-        conn.executescript(USER_PREFERENCES_SCHEMA)
+        conn.execute(USER_PREFERENCES_SCHEMA)
         conn.execute("DROP TABLE user_preferences_legacy")
 
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,6 +1,7 @@
 """Pydantic models for database entities."""
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -25,12 +26,19 @@ class AccessRequest(BaseModel):
     status: str = "pending"  # pending, approved, rejected
 
 
-class UserPreference(BaseModel):
-    """User preferences (timezone, etc.)."""
+class UserProfile(BaseModel):
+    """Explicitly consented booking profile fields."""
 
     telegram_id: int
-    timezone: str
+    preferred_name: str | None = None
+    timezone: str | None = None
+    email_mode: Literal["ask", "private", "saved"] = "ask"
+    email: str | None = None
     updated_at: datetime
+
+
+# Compatibility for code/tests written against the original timezone-only model.
+UserPreference = UserProfile
 
 
 class StoredBooking(BaseModel):

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -6,6 +6,15 @@ from app.handlers.booking import (
     create_cancel_booking_flow_handlers,
 )
 from app.handlers.help import help_command
+from app.handlers.privacy import (
+    PrivacyState,
+    create_privacy_conversation_handler,
+    privacy_callback,
+    privacy_command,
+    privacy_enter_email,
+    privacy_enter_name,
+    privacy_select_timezone,
+)
 from app.handlers.start import start_command, text_onboarding_or_help
 
 __all__ = [
@@ -13,7 +22,14 @@ __all__ = [
     "create_booking_conversation_handler",
     "create_cancel_booking_flow_handlers",
     "help_command",
+    "PrivacyState",
+    "create_privacy_conversation_handler",
     "pending_command",
+    "privacy_callback",
+    "privacy_command",
+    "privacy_enter_email",
+    "privacy_enter_name",
+    "privacy_select_timezone",
     "reject_command",
     "start_command",
     "text_onboarding_or_help",

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -9,11 +9,14 @@ from app.handlers.help import help_command
 from app.handlers.privacy import (
     PrivacyState,
     create_privacy_conversation_handler,
+    invalidate_pending_privacy_input,
     privacy_callback,
+    privacy_cancel,
     privacy_command,
     privacy_enter_email,
     privacy_enter_name,
     privacy_select_timezone,
+    privacy_timeout,
 )
 from app.handlers.start import start_command, text_onboarding_or_help
 
@@ -24,12 +27,15 @@ __all__ = [
     "help_command",
     "PrivacyState",
     "create_privacy_conversation_handler",
+    "invalidate_pending_privacy_input",
     "pending_command",
     "privacy_callback",
+    "privacy_cancel",
     "privacy_command",
     "privacy_enter_email",
     "privacy_enter_name",
     "privacy_select_timezone",
+    "privacy_timeout",
     "reject_command",
     "start_command",
     "text_onboarding_or_help",

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -19,12 +19,14 @@ from app.handlers.privacy import (
     privacy_timeout,
 )
 from app.handlers.start import start_command, text_onboarding_or_help
+from app.handlers.user_conversation import create_user_conversation_handler
 
 __all__ = [
     "approve_command",
     "create_booking_conversation_handler",
     "create_cancel_booking_flow_handlers",
     "help_command",
+    "create_user_conversation_handler",
     "PrivacyState",
     "create_privacy_conversation_handler",
     "invalidate_pending_privacy_input",

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -20,6 +20,8 @@ from telegram.ext import (
 
 from app.config import settings
 from app.constants import (
+    MAX_EMAIL_LENGTH,
+    MAX_NAME_LENGTH,
     RUSSIAN_TIMEZONES,
     SUPPORTED_BOOKING_DURATIONS,
     SUPPORTED_TIMEZONE_IDS,
@@ -64,7 +66,6 @@ RUSSIAN_MONTHS_ABBR = [
 ]
 
 TIMEZONE_BUTTON_LABEL = "Часовой пояс"
-MAX_NAME_LENGTH = 100
 
 DURATION_OPTIONS = {minutes: f"{minutes} минут" for minutes in SUPPORTED_BOOKING_DURATIONS}
 FIFTH_STEP_RESTRICTION_TEXT = "двухчасовые встречи предназначены только для работы по 5-му шагу."
@@ -778,6 +779,12 @@ async def enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     """Store email and show confirmation."""
     _refresh_booking_timeout_reminder(context, update.effective_user.id)
     email = update.message.text.strip()
+
+    if len(email) > MAX_EMAIL_LENGTH:
+        await update.message.reply_text(
+            f"Email слишком длинный. Введите до {MAX_EMAIL_LENGTH} символов:"
+        )
+        return BookingState.ENTERING_EMAIL
 
     if "@" not in email or "." not in email.split("@")[-1]:
         await update.message.reply_text("Некорректный email. Попробуйте ещё раз:")

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -100,6 +100,7 @@ BOOKING_SCOPED_USER_DATA_KEYS = frozenset(
         "email",
         "email_mode",
         "remember_choices",
+        "remembered_profile_fields",
         "edit_field",
         "internal_ref",
     }
@@ -387,18 +388,24 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
                 type(error).__name__,
             )
         else:
+            remembered_fields = set()
             if profile is not None:
                 if profile.preferred_name:
                     context.user_data["name"] = profile.preferred_name
+                    remembered_fields.add("name")
                 context.user_data["email_mode"] = profile.email_mode
                 if profile.email_mode == "saved" and profile.email:
                     context.user_data["email"] = profile.email
+                    remembered_fields.add("email")
                 elif profile.email_mode == "private":
                     context.user_data["email"] = None
+                    remembered_fields.add("private")
 
             if profile is not None and profile.timezone in SUPPORTED_TIMEZONE_IDS:
                 context.user_data["timezone"] = profile.timezone
                 context.user_data["offset_days"] = 0
+                remembered_fields.add("timezone")
+                context.user_data["remembered_profile_fields"] = remembered_fields
                 target = _MessageReplyTarget(
                     update.message,
                     update.effective_user.id,
@@ -410,6 +417,8 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
                     "Ignoring unsupported timezone in booking profile for user_id=%s",
                     update.effective_user.id,
                 )
+            if remembered_fields:
+                context.user_data["remembered_profile_fields"] = remembered_fields
 
     keyboard = build_timezone_keyboard()
     prefix = _profile_reuse_message(context.user_data)
@@ -853,6 +862,7 @@ def _remembering_text(data: dict, *, reused: bool = False) -> str:
     prefix = f"{reuse_message}\n\n" if reuse_message else ""
     return (
         f"{prefix}Какие данные запомнить для следующих записей?\n\n"
+        "Уже сохраненные поля отмечены отдельно. "
         "Сохранится только то, что вы явно выберете. "
         "Можно продолжить, ничего не сохраняя."
     )
@@ -860,9 +870,20 @@ def _remembering_text(data: dict, *, reused: bool = False) -> str:
 
 def _remembering_keyboard(data: dict) -> InlineKeyboardMarkup:
     choices = set(data.get("remember_choices", set()))
+    remembered = set(data.get("remembered_profile_fields", set()))
     buttons = []
 
     def option(label: str, field: str) -> None:
+        if field in remembered:
+            buttons.append(
+                [
+                    InlineKeyboardButton(
+                        f"✓ {label} — уже сохранено",
+                        callback_data="remember:kept",
+                    )
+                ]
+            )
+            return
         marker = "✓ " if field in choices else ""
         buttons.append(
             [InlineKeyboardButton(f"{marker}{label}", callback_data=f"remember:{field}")]
@@ -876,6 +897,7 @@ def _remembering_keyboard(data: dict) -> InlineKeyboardMarkup:
         option("Предпочитать запись без личного email", "private")
     buttons.append([InlineKeyboardButton("Сохранить выбранное", callback_data="remember:save")])
     buttons.append([InlineKeyboardButton("Ничего не сохранять", callback_data="remember:none")])
+    buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
     return InlineKeyboardMarkup(buttons)
 
 
@@ -885,6 +907,10 @@ async def remember_profile_choice(update: Update, context: ContextTypes.DEFAULT_
     await query.answer()
     _refresh_booking_timeout_reminder(context, query.from_user.id)
     action = query.data.split(":", 1)[1]
+    remembered = set(context.user_data.get("remembered_profile_fields", set()))
+
+    if action == "kept":
+        return BookingState.REMEMBERING_PROFILE
 
     if action == "none":
         context.user_data.pop("remember_choices", None)
@@ -894,13 +920,14 @@ async def remember_profile_choice(update: Update, context: ContextTypes.DEFAULT_
         notice = _persist_profile_choices(
             context,
             query.from_user.id,
-            set(context.user_data.get("remember_choices", set())),
+            set(context.user_data.get("remember_choices", set())) - remembered,
         )
         context.user_data.pop("remember_choices", None)
         return await _show_confirmation_edit(query, context, notice=notice)
 
     available = {"name", "timezone"}
     available.add("email" if context.user_data.get("email") else "private")
+    available -= remembered
     if action not in available:
         return BookingState.REMEMBERING_PROFILE
 
@@ -1051,10 +1078,12 @@ async def edit_booking_field(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if field == "back":
         return await _show_confirmation_edit(query, context)
     if field == "name":
+        _mark_profile_field_transient(context.user_data, "name")
         context.user_data["edit_field"] = "name"
         await _safe_edit_message_text(query, "Введите имя для этой записи:")
         return BookingState.ENTERING_NAME
     if field == "timezone":
+        _mark_profile_field_transient(context.user_data, "timezone")
         context.user_data["edit_field"] = "timezone"
         await _safe_edit_message_text(
             query,
@@ -1063,14 +1092,25 @@ async def edit_booking_field(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
         return BookingState.SELECTING_TIMEZONE
     if field == "email":
+        _mark_profile_field_transient(context.user_data, "email")
         context.user_data["edit_field"] = "email"
         await _safe_edit_message_text(query, "Введите email для этой записи:")
         return BookingState.ENTERING_EMAIL
     if field == "private":
+        _mark_profile_field_transient(context.user_data, "private")
         context.user_data["email"] = None
         context.user_data["email_mode"] = "private"
         return await _show_remembering_edit(query, context)
     return BookingState.CONFIRMING
+
+
+def _mark_profile_field_transient(data: dict, field: str) -> None:
+    remembered = set(data.get("remembered_profile_fields", set()))
+    if field in {"email", "private"}:
+        remembered.difference_update({"email", "private"})
+    else:
+        remembered.discard(field)
+    data["remembered_profile_fields"] = remembered
 
 
 # ---------------------------------------------------------------------------

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -452,7 +452,9 @@ async def select_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     _refresh_booking_timeout_reminder(context, query.from_user.id)
 
     if context.user_data.pop("edit_field", None) == "timezone":
-        return await _show_remembering_edit(query, context)
+        context.user_data.pop("selected_date", None)
+        context.user_data.pop("selected_time", None)
+        return await _show_availability(query, context, offset_days=0)
 
     return await _handle_duration_selection(query, context)
 

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -19,7 +19,11 @@ from telegram.ext import (
 )
 
 from app.config import settings
-from app.constants import RUSSIAN_TIMEZONES, SUPPORTED_BOOKING_DURATIONS
+from app.constants import (
+    RUSSIAN_TIMEZONES,
+    SUPPORTED_BOOKING_DURATIONS,
+    SUPPORTED_TIMEZONE_IDS,
+)
 from app.services.booking_service import BookingService
 from app.services.calcom_client import (
     Attendee,
@@ -62,13 +66,8 @@ RUSSIAN_MONTHS_ABBR = [
 TIMEZONE_BUTTON_LABEL = "Часовой пояс"
 MAX_NAME_LENGTH = 100
 
-DURATION_OPTIONS = {
-    minutes: f"{minutes} минут" for minutes in SUPPORTED_BOOKING_DURATIONS
-}
-SUPPORTED_TIMEZONE_IDS = frozenset(timezone_id for timezone_id, _ in RUSSIAN_TIMEZONES)
-FIFTH_STEP_RESTRICTION_TEXT = (
-    "двухчасовые встречи предназначены только для работы по 5-му шагу."
-)
+DURATION_OPTIONS = {minutes: f"{minutes} минут" for minutes in SUPPORTED_BOOKING_DURATIONS}
+FIFTH_STEP_RESTRICTION_TEXT = "двухчасовые встречи предназначены только для работы по 5-му шагу."
 FIFTH_STEP_WARNING_TEXT = (
     f"Важно: {FIFTH_STEP_RESTRICTION_TEXT}\n\n"
     "Если вы записываетесь не для 5-го шага, пожалуйста, выберите длительность "
@@ -98,6 +97,9 @@ BOOKING_SCOPED_USER_DATA_KEYS = frozenset(
         "selected_time",
         "name",
         "email",
+        "email_mode",
+        "remember_choices",
+        "edit_field",
         "internal_ref",
     }
 )
@@ -116,6 +118,7 @@ class BookingState(IntEnum):
     ENTERING_NAME = auto()
     EMAIL_DECISION = auto()
     ENTERING_EMAIL = auto()
+    REMEMBERING_PROFILE = auto()
     CONFIRMING = auto()
 
 
@@ -340,13 +343,28 @@ async def _send_booking_timeout_reminder(context: ContextTypes.DEFAULT_TYPE) -> 
         )
 
 
+def _profile_reuse_message(data: dict) -> str | None:
+    lines = []
+    if data.get("name"):
+        lines.append(f"Имя: {data['name']}")
+    if data.get("timezone"):
+        lines.append(f"Часовой пояс: {data['timezone']}")
+    if data.get("email_mode") == "saved" and data.get("email"):
+        lines.append("Email: используем сохраненный адрес")
+    elif data.get("email_mode") == "private":
+        lines.append("Email: без личного адреса")
+    if not lines:
+        return None
+    return "Используем сохраненные данные:\n" + "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
 async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    """Start the booking conversation with timezone selection."""
+    """Start booking with only the profile fields the user explicitly saved."""
     _clear_booking_scoped_state(context)
     if not _is_whitelisted(update, context):
         _cancel_booking_timeout_reminder(context, update.effective_user.id)
@@ -360,32 +378,44 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     )
     if preference_service is not None:
         try:
-            preference = preference_service.get_timezone(update.effective_user.id)
+            profile = preference_service.get_profile(update.effective_user.id)
         except Exception:
             logger.exception(
-                "Failed to load timezone preference for user_id=%s",
+                "Failed to load booking profile for user_id=%s",
                 update.effective_user.id,
             )
         else:
-            if preference is not None and preference.timezone in SUPPORTED_TIMEZONE_IDS:
-                context.user_data["timezone"] = preference.timezone
+            if profile is not None:
+                if profile.preferred_name:
+                    context.user_data["name"] = profile.preferred_name
+                context.user_data["email_mode"] = profile.email_mode
+                if profile.email_mode == "saved" and profile.email:
+                    context.user_data["email"] = profile.email
+                elif profile.email_mode == "private":
+                    context.user_data["email"] = None
+
+            if profile is not None and profile.timezone in SUPPORTED_TIMEZONE_IDS:
+                context.user_data["timezone"] = profile.timezone
                 context.user_data["offset_days"] = 0
                 target = _MessageReplyTarget(
                     update.message,
                     update.effective_user.id,
-                    prefix=f"Используем сохраненный часовой пояс: {preference.timezone}.",
+                    prefix=_profile_reuse_message(context.user_data),
                 )
                 return await _handle_duration_selection(target, context)
-            if preference is not None:
+            if profile is not None and profile.timezone is not None:
                 logger.warning(
-                    "Ignoring unsupported timezone preference for user_id=%s timezone=%s",
+                    "Ignoring unsupported timezone in booking profile for user_id=%s",
                     update.effective_user.id,
-                    preference.timezone,
                 )
 
     keyboard = build_timezone_keyboard()
+    prefix = _profile_reuse_message(context.user_data)
+    message = "Выберите ваш часовой пояс:"
+    if prefix:
+        message = f"{prefix}\n\n{message}"
     await update.message.reply_text(
-        "Выберите ваш часовой пояс:",
+        message,
         reply_markup=keyboard,
     )
     return BookingState.SELECTING_TIMEZONE
@@ -401,25 +431,35 @@ async def select_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     await query.answer()
 
-    timezone_id = query.data.split(":", 1)[1]
-    previous_timezone = context.user_data.get("timezone")
+    timezone_id = _timezone_from_callback(query.data)
+    if timezone_id is None:
+        return BookingState.SELECTING_TIMEZONE
+
     context.user_data["timezone"] = timezone_id
     context.user_data["offset_days"] = 0
-    preference_service: UserPreferenceService | None = context.bot_data.get(
-        "user_preference_service"
-    )
-    if preference_service is not None and timezone_id != previous_timezone:
-        try:
-            preference_service.set_timezone(query.from_user.id, timezone_id)
-        except Exception:
-            logger.exception(
-                "Failed to persist timezone preference for user_id=%s timezone=%s",
-                query.from_user.id,
-                timezone_id,
-            )
     _refresh_booking_timeout_reminder(context, query.from_user.id)
 
+    if context.user_data.pop("edit_field", None) == "timezone":
+        return await _show_remembering_edit(query, context)
+
     return await _handle_duration_selection(query, context)
+
+
+def _timezone_from_callback(callback_data: str) -> str | None:
+    """Resolve current opaque timezone callbacks and tolerate old rendered keyboards."""
+    try:
+        value = callback_data.split(":", 1)[1]
+    except IndexError:
+        return None
+
+    try:
+        index = int(value)
+    except ValueError:
+        return value if value in SUPPORTED_TIMEZONE_IDS else None
+
+    if index < 0 or index >= len(RUSSIAN_TIMEZONES):
+        return None
+    return RUSSIAN_TIMEZONES[index][0]
 
 
 async def _handle_duration_selection(query, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -611,13 +651,13 @@ async def _show_availability(
                     [
                         InlineKeyboardButton(
                             "Попробовать снова",
-                            callback_data=f"tz:{timezone_id}",
+                            callback_data="retry:availability",
                         ),
                     ],
                     [
                         InlineKeyboardButton(TIMEZONE_BUTTON_LABEL, callback_data="change_tz"),
                         InlineKeyboardButton("Отмена", callback_data="cancel"),
-                    ]
+                    ],
                 ]
             ),
         )
@@ -631,6 +671,14 @@ async def load_more_dates(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     offset_days = int(query.data.split(":")[1])
     context.user_data["offset_days"] = offset_days
+    return await _show_availability(query, context, offset_days=offset_days)
+
+
+async def retry_availability(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Retry availability using transient booking state, not callback values."""
+    query = update.callback_query
+    await query.answer()
+    offset_days = context.user_data.get("offset_days", 0)
     return await _show_availability(query, context, offset_days=offset_days)
 
 
@@ -648,7 +696,7 @@ async def noop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 
 async def select_slot(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    """Handle time slot selection and prompt for name."""
+    """Handle a time slot and reuse explicitly remembered contact fields."""
     query = update.callback_query
     await query.answer()
     _refresh_booking_timeout_reminder(context, query.from_user.id)
@@ -657,6 +705,9 @@ async def select_slot(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     parts = query.data.split(":", 2)
     context.user_data["selected_date"] = parts[1]
     context.user_data["selected_time"] = parts[2]
+
+    if context.user_data.get("name"):
+        return await _continue_after_name_edit(query, context, reused=True)
 
     await _safe_edit_message_text(query, "Введите ваше имя:")
     return BookingState.ENTERING_NAME
@@ -685,14 +736,15 @@ async def enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
     context.user_data["name"] = name
 
-    keyboard = InlineKeyboardMarkup(
-        [
-            [
-                InlineKeyboardButton("Да, указать email", callback_data="email_yes"),
-                InlineKeyboardButton("Нет, пропустить", callback_data="email_no"),
-            ]
-        ]
-    )
+    if context.user_data.pop("edit_field", None) == "name":
+        await _show_remembering_message(update.message, context)
+        return BookingState.REMEMBERING_PROFILE
+
+    if _has_reusable_email_choice(context.user_data):
+        await _show_remembering_message(update.message, context, reused=True)
+        return BookingState.REMEMBERING_PROFILE
+
+    keyboard = _email_decision_keyboard()
     await update.message.reply_text(
         f"Отлично, {name}! Хотите указать email для подтверждения?",
         reply_markup=keyboard,
@@ -716,7 +768,8 @@ async def email_decision(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         return BookingState.ENTERING_EMAIL
     else:
         context.user_data["email"] = None
-        return await _show_confirmation_edit(query, context)
+        context.user_data["email_mode"] = "private"
+        return await _show_remembering_edit(query, context)
 
 
 async def enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -729,8 +782,168 @@ async def enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
         return BookingState.ENTERING_EMAIL
 
     context.user_data["email"] = email
-    await _show_confirmation_message(update.message, context)
-    return BookingState.CONFIRMING
+    context.user_data["email_mode"] = "saved"
+    context.user_data.pop("edit_field", None)
+    await _show_remembering_message(update.message, context)
+    return BookingState.REMEMBERING_PROFILE
+
+
+async def _continue_after_name_edit(query, context, *, reused: bool = False) -> int:
+    """Continue from name using only an explicitly remembered email choice."""
+    if _has_reusable_email_choice(context.user_data):
+        return await _show_remembering_edit(query, context, reused=reused)
+
+    prefix = "Используем сохраненное имя.\n\n" if reused else ""
+    await _safe_edit_message_text(
+        query,
+        f"{prefix}Хотите указать email для подтверждения?",
+        reply_markup=_email_decision_keyboard(),
+    )
+    return BookingState.EMAIL_DECISION
+
+
+def _has_reusable_email_choice(data: dict) -> bool:
+    mode = data.get("email_mode")
+    return (mode == "saved" and bool(data.get("email"))) or mode == "private"
+
+
+def _email_decision_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Да, указать email", callback_data="email_yes"),
+                InlineKeyboardButton("Нет, пропустить", callback_data="email_no"),
+            ]
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Granular profile consent
+# ---------------------------------------------------------------------------
+
+
+async def _show_remembering_edit(query, context, *, reused: bool = False) -> int:
+    await _safe_edit_message_text(
+        query,
+        _remembering_text(context.user_data, reused=reused),
+        reply_markup=_remembering_keyboard(context.user_data),
+    )
+    return BookingState.REMEMBERING_PROFILE
+
+
+async def _show_remembering_message(message, context, *, reused: bool = False) -> None:
+    await message.reply_text(
+        _remembering_text(context.user_data, reused=reused),
+        reply_markup=_remembering_keyboard(context.user_data),
+    )
+
+
+def _remembering_text(data: dict, *, reused: bool = False) -> str:
+    reuse_message = _profile_reuse_message(data) if reused else None
+    prefix = f"{reuse_message}\n\n" if reuse_message else ""
+    return (
+        f"{prefix}Какие данные запомнить для следующих записей?\n\n"
+        "Сохранится только то, что вы явно выберете. "
+        "Можно продолжить, ничего не сохраняя."
+    )
+
+
+def _remembering_keyboard(data: dict) -> InlineKeyboardMarkup:
+    choices = set(data.get("remember_choices", set()))
+    buttons = []
+
+    def option(label: str, field: str) -> None:
+        marker = "✓ " if field in choices else ""
+        buttons.append(
+            [InlineKeyboardButton(f"{marker}{label}", callback_data=f"remember:{field}")]
+        )
+
+    option("Запомнить имя", "name")
+    option("Запомнить часовой пояс", "timezone")
+    if data.get("email"):
+        option("Запомнить email", "email")
+    else:
+        option("Предпочитать запись без личного email", "private")
+    buttons.append([InlineKeyboardButton("Сохранить выбранное", callback_data="remember:save")])
+    buttons.append([InlineKeyboardButton("Ничего не сохранять", callback_data="remember:none")])
+    return InlineKeyboardMarkup(buttons)
+
+
+async def remember_profile_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Toggle granular consent or persist only the selected profile fields."""
+    query = update.callback_query
+    await query.answer()
+    _refresh_booking_timeout_reminder(context, query.from_user.id)
+    action = query.data.split(":", 1)[1]
+
+    if action == "none":
+        context.user_data.pop("remember_choices", None)
+        return await _show_confirmation_edit(query, context)
+
+    if action == "save":
+        notice = _persist_profile_choices(
+            context,
+            query.from_user.id,
+            set(context.user_data.get("remember_choices", set())),
+        )
+        context.user_data.pop("remember_choices", None)
+        return await _show_confirmation_edit(query, context, notice=notice)
+
+    available = {"name", "timezone"}
+    available.add("email" if context.user_data.get("email") else "private")
+    if action not in available:
+        return BookingState.REMEMBERING_PROFILE
+
+    choices = set(context.user_data.get("remember_choices", set()))
+    if action in choices:
+        choices.remove(action)
+    else:
+        choices.add(action)
+    context.user_data["remember_choices"] = choices
+    return await _show_remembering_edit(query, context)
+
+
+def _persist_profile_choices(context, user_id: int, choices: set[str]) -> str | None:
+    if not choices:
+        return "Новые данные не сохранены."
+
+    profile_service: UserPreferenceService | None = context.bot_data.get("user_preference_service")
+    if profile_service is None:
+        return "Не удалось сохранить выбранные данные. Запись продолжится без изменений профиля."
+
+    data = context.user_data
+    operations = {
+        "name": lambda: profile_service.save_preferred_name(user_id, data["name"]),
+        "timezone": lambda: profile_service.save_timezone(user_id, data["timezone"]),
+        "email": lambda: profile_service.save_email(user_id, data["email"]),
+        "private": lambda: profile_service.save_private_email_mode(user_id),
+    }
+    labels = {
+        "name": "имя",
+        "timezone": "часовой пояс",
+        "email": "email",
+        "private": "режим без личного email",
+    }
+    saved = []
+    failed = False
+    for field in ("name", "timezone", "email", "private"):
+        if field not in choices:
+            continue
+        try:
+            operations[field]()
+        except Exception:
+            failed = True
+            logger.exception(
+                "Failed to persist selected booking profile field for user_id=%s",
+                user_id,
+            )
+        else:
+            saved.append(labels[field])
+
+    if failed:
+        return "Не все выбранные данные удалось сохранить. Запись продолжится."
+    return f"Сохранено для следующих записей: {', '.join(saved)}."
 
 
 # ---------------------------------------------------------------------------
@@ -738,9 +951,16 @@ async def enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 # ---------------------------------------------------------------------------
 
 
-async def _show_confirmation_edit(query, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _show_confirmation_edit(
+    query,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    notice: str | None = None,
+) -> int:
     """Edit message to show booking confirmation."""
     text = _build_confirmation_text(context.user_data)
+    if notice:
+        text = f"{notice}\n\n{text}"
     keyboard = _confirmation_keyboard()
     await _safe_edit_message_text(query, text, reply_markup=keyboard)
     return BookingState.CONFIRMING
@@ -761,12 +981,9 @@ def _build_confirmation_text(data: dict) -> str:
     )
     duration = data.get("duration", 30)
     duration_text = DURATION_OPTIONS.get(duration, f"{duration} мин.")
-    email_line = f"\nEmail: {data['email']}" if data.get("email") else ""
-    fifth_step_warning = (
-        f"\n\nВажно: {FIFTH_STEP_RESTRICTION_TEXT}"
-        if duration == 120
-        else ""
-    )
+    email_value = data.get("email") or "без личного email"
+    email_line = f"\nEmail: {email_value}"
+    fifth_step_warning = f"\n\nВажно: {FIFTH_STEP_RESTRICTION_TEXT}" if duration == 120 else ""
     return (
         f"Подтвердите запись:\n\n"
         f"Время: {formatted_time}\n"
@@ -784,9 +1001,66 @@ def _confirmation_keyboard() -> InlineKeyboardMarkup:
             [
                 InlineKeyboardButton("Подтвердить запись", callback_data="confirm"),
                 InlineKeyboardButton("Отмена", callback_data="cancel"),
-            ]
+            ],
+            [InlineKeyboardButton("Изменить данные", callback_data="edit:data")],
         ]
     )
+
+
+async def edit_booking_data(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Show value-free controls for changing effective booking details."""
+    query = update.callback_query
+    await query.answer()
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Изменить имя", callback_data="edit:name"),
+                InlineKeyboardButton("Изменить часовой пояс", callback_data="edit:timezone"),
+            ],
+            [
+                InlineKeyboardButton("Изменить email", callback_data="edit:email"),
+                InlineKeyboardButton("Без личного email", callback_data="edit:private"),
+            ],
+            [InlineKeyboardButton("Назад", callback_data="edit:back")],
+        ]
+    )
+    await _safe_edit_message_text(
+        query,
+        "Что изменить в данных этой записи?",
+        reply_markup=keyboard,
+    )
+    return BookingState.CONFIRMING
+
+
+async def edit_booking_field(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Collect one changed booking value without changing saved consent."""
+    query = update.callback_query
+    await query.answer()
+    field = query.data.split(":", 1)[1]
+
+    if field == "back":
+        return await _show_confirmation_edit(query, context)
+    if field == "name":
+        context.user_data["edit_field"] = "name"
+        await _safe_edit_message_text(query, "Введите имя для этой записи:")
+        return BookingState.ENTERING_NAME
+    if field == "timezone":
+        context.user_data["edit_field"] = "timezone"
+        await _safe_edit_message_text(
+            query,
+            "Выберите часовой пояс для этой записи:",
+            reply_markup=build_timezone_keyboard(),
+        )
+        return BookingState.SELECTING_TIMEZONE
+    if field == "email":
+        context.user_data["edit_field"] = "email"
+        await _safe_edit_message_text(query, "Введите email для этой записи:")
+        return BookingState.ENTERING_EMAIL
+    if field == "private":
+        context.user_data["email"] = None
+        context.user_data["email_mode"] = "private"
+        return await _show_remembering_edit(query, context)
+    return BookingState.CONFIRMING
 
 
 # ---------------------------------------------------------------------------
@@ -827,11 +1101,10 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         resolved_event_type = settings.resolve_event_type(duration)
         start_utc = slot_to_utc(data["selected_time"])
         logger.info(
-            "Creating booking for user_id=%s event_type_id=%s start_utc=%s timezone=%s",
+            "Creating booking for user_id=%s event_type_id=%s start_utc=%s",
             update.effective_user.id,
             resolved_event_type.event_type_id,
             start_utc,
-            data.get("timezone"),
         )
 
         booking = await calcom_client.create_booking(
@@ -879,9 +1152,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             data["timezone"],
         )
         duration_str = _format_duration(booking)
-        email_note = (
-            f"\nПисьмо с подтверждением отправлено на {email}." if personal_email else ""
-        )
+        email_note = f"\nПисьмо с подтверждением отправлено на {email}." if personal_email else ""
 
         await _safe_edit_message_text(
             query,
@@ -896,11 +1167,10 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     except CalComAPIError as e:
         logger.warning(
-            "Booking create failed for user_id=%s status=%s code=%s message=%s",
+            "Booking create failed for user_id=%s status=%s code=%s",
             update.effective_user.id,
             e.status_code,
             e.code,
-            e.message,
         )
         if e.code == EMAIL_DOMAIN_CANNOT_RECEIVE_MAIL:
             if not personal_email:
@@ -922,7 +1192,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 [
                     InlineKeyboardButton(
                         "Выбрать другое время",
-                        callback_data=f"tz:{data['timezone']}",
+                        callback_data="retry:availability",
                     ),
                     InlineKeyboardButton("Отмена", callback_data="cancel"),
                 ]
@@ -940,7 +1210,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 [
                     InlineKeyboardButton(
                         "Выбрать другое время",
-                        callback_data=f"tz:{data['timezone']}",
+                        callback_data="retry:availability",
                     ),
                     InlineKeyboardButton("Отмена", callback_data="cancel"),
                 ]
@@ -1160,8 +1430,8 @@ def create_cancel_booking_flow_handlers() -> list:
 def build_timezone_keyboard() -> InlineKeyboardMarkup:
     """Build timezone selection keyboard."""
     buttons = [
-        [InlineKeyboardButton(label, callback_data=f"tz:{tz_id}")]
-        for tz_id, label in RUSSIAN_TIMEZONES
+        [InlineKeyboardButton(label, callback_data=f"tz:{index}")]
+        for index, (_, label) in enumerate(RUSSIAN_TIMEZONES)
     ]
     buttons.append([InlineKeyboardButton("Отмена", callback_data="cancel")])
     return InlineKeyboardMarkup(buttons)
@@ -1349,6 +1619,7 @@ def create_booking_conversation_handler() -> ConversationHandler:
             BookingState.VIEWING_AVAILABILITY: [
                 CallbackQueryHandler(select_slot, pattern="^slot:"),
                 CallbackQueryHandler(load_more_dates, pattern="^dates:"),
+                CallbackQueryHandler(retry_availability, pattern="^retry:availability$"),
                 CallbackQueryHandler(change_timezone, pattern="^change_tz$"),
                 CallbackQueryHandler(select_timezone, pattern="^tz:"),
                 CallbackQueryHandler(noop, pattern="^noop$"),
@@ -1364,9 +1635,16 @@ def create_booking_conversation_handler() -> ConversationHandler:
             BookingState.ENTERING_EMAIL: [
                 MessageHandler(filters.TEXT & ~filters.COMMAND, enter_email),
             ],
+            BookingState.REMEMBERING_PROFILE: [
+                CallbackQueryHandler(remember_profile_choice, pattern="^remember:"),
+                CallbackQueryHandler(cancel, pattern="^cancel$"),
+            ],
             BookingState.CONFIRMING: [
                 CallbackQueryHandler(confirm_booking, pattern="^confirm$"),
-                CallbackQueryHandler(select_timezone, pattern="^tz:"),
+                CallbackQueryHandler(edit_booking_data, pattern="^edit:data$"),
+                CallbackQueryHandler(
+                    edit_booking_field, pattern="^edit:(name|timezone|email|private|back)$"
+                ),
                 CallbackQueryHandler(cancel, pattern="^cancel$"),
             ],
             ConversationHandler.TIMEOUT: [TypeHandler(Update, booking_timeout)],

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -1227,6 +1227,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             if not personal_email:
                 return await _show_privacy_email_unavailable(query)
 
+            _mark_profile_field_transient(data, "email")
             data.pop("email", None)
             await _safe_edit_message_text(
                 query,

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -103,6 +103,7 @@ BOOKING_SCOPED_USER_DATA_KEYS = frozenset(
         "remembered_profile_fields",
         "edit_field",
         "internal_ref",
+        "active_user_conversation",
     }
 )
 EMAIL_DOMAIN_CANNOT_RECEIVE_MAIL = "email_domain_cannot_receive_mail"
@@ -1214,6 +1215,7 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             f"{email_note}",
         )
         _cancel_booking_timeout_reminder(context, update.effective_user.id)
+        _clear_booking_scoped_state(context)
         return ConversationHandler.END
 
     except CalComAPIError as e:

--- a/app/handlers/booking.py
+++ b/app/handlers/booking.py
@@ -379,10 +379,11 @@ async def book_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     if preference_service is not None:
         try:
             profile = preference_service.get_profile(update.effective_user.id)
-        except Exception:
-            logger.exception(
-                "Failed to load booking profile for user_id=%s",
+        except Exception as error:
+            logger.error(
+                "Failed to load booking profile for user_id=%s error_type=%s",
                 update.effective_user.id,
+                type(error).__name__,
             )
         else:
             if profile is not None:
@@ -637,11 +638,12 @@ async def _show_availability(
         )
         return BookingState.VIEWING_AVAILABILITY
 
-    except (CalComAPIError, ValueError):
-        logger.exception(
-            "Failed to load availability for user_id=%s duration=%s",
+    except (CalComAPIError, ValueError) as error:
+        logger.error(
+            "Failed to load availability for user_id=%s duration=%s error_type=%s",
             query.from_user.id,
             duration,
+            type(error).__name__,
         )
         await _safe_edit_message_text(
             query,
@@ -932,11 +934,12 @@ def _persist_profile_choices(context, user_id: int, choices: set[str]) -> str | 
             continue
         try:
             operations[field]()
-        except Exception:
+        except Exception as error:
             failed = True
-            logger.exception(
-                "Failed to persist selected booking profile field for user_id=%s",
+            logger.error(
+                "Failed to persist selected booking profile field for user_id=%s error_type=%s",
                 user_id,
+                type(error).__name__,
             )
         else:
             saved.append(labels[field])
@@ -1131,11 +1134,12 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                     booking,
                     internal_ref=internal_ref,
                 )
-            except Exception:
-                logger.exception(
-                    "Failed to persist booking for user_id=%s booking_id=%s",
+            except Exception as error:
+                logger.error(
+                    "Failed to persist booking for user_id=%s booking_id=%s error_type=%s",
                     update.effective_user.id,
                     booking.id,
+                    type(error).__name__,
                 )
 
         logger.info(
@@ -1200,10 +1204,11 @@ async def confirm_booking(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         await _safe_edit_message_text(query, error_msg, reply_markup=keyboard)
         return BookingState.VIEWING_AVAILABILITY
-    except Exception:
-        logger.exception(
-            "Unexpected error while creating booking for user_id=%s",
+    except Exception as error:
+        logger.error(
+            "Unexpected error while creating booking for user_id=%s error_type=%s",
             update.effective_user.id,
+            type(error).__name__,
         )
         keyboard = InlineKeyboardMarkup(
             [

--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -19,7 +19,8 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not whitelist_service.is_whitelisted(user_id):
         await update.message.reply_text(
             "Доступные команды:\n\n"
-            "/start — Запросить доступ к боту"
+            "/start — Запросить доступ к боту\n"
+            "/privacy — Управлять сохраненными данными"
         )
         return
 
@@ -27,6 +28,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "Доступные команды:\n",
         "/book — Записаться на встречу",
         "/cancel_booking — Отменить существующую запись",
+        "/privacy — Управлять сохраненными данными",
         "/help — Показать список команд",
     ]
 

--- a/app/handlers/privacy.py
+++ b/app/handlers/privacy.py
@@ -1,0 +1,261 @@
+"""Reversible management of explicitly remembered booking profile fields."""
+
+import logging
+from enum import IntEnum, auto
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import (
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+)
+
+from app.constants import RUSSIAN_TIMEZONES
+from app.services.user_preferences import UserPreferenceService
+
+logger = logging.getLogger(__name__)
+
+PROFILE_DELETE_NOTICE = "Удаление настроек не отменяет и не удаляет активные записи."
+TELEGRAM_ACCESS_NOTICE = (
+    "Данные доступа Telegram управляются отдельно и в этом разделе не изменяются."
+)
+
+
+class PrivacyState(IntEnum):
+    """States for the /privacy profile-management conversation."""
+
+    VIEWING = auto()
+    ENTERING_NAME = auto()
+    SELECTING_TIMEZONE = auto()
+    ENTERING_EMAIL = auto()
+    END = ConversationHandler.END
+
+
+async def privacy_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Display remembered fields without requiring current whitelist access."""
+    profile = _load_profile(context, update.effective_user.id)
+    await update.message.reply_text(
+        _privacy_summary(profile),
+        reply_markup=_privacy_keyboard(profile),
+    )
+    return PrivacyState.VIEWING
+
+
+async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Change, forget, or delete remembered profile fields."""
+    query = update.callback_query
+    await query.answer()
+    action = query.data.split(":", 1)[1]
+    user_id = query.from_user.id
+    service = _profile_service(context)
+
+    if action == "edit_name":
+        await query.edit_message_text("Введите имя, которое нужно запомнить:")
+        return PrivacyState.ENTERING_NAME
+    if action == "edit_timezone":
+        await query.edit_message_text(
+            "Выберите часовой пояс, который нужно запомнить:",
+            reply_markup=_privacy_timezone_keyboard(),
+        )
+        return PrivacyState.SELECTING_TIMEZONE
+    if action == "edit_email":
+        await query.edit_message_text("Введите email, который нужно запомнить:")
+        return PrivacyState.ENTERING_EMAIL
+    if action == "delete_confirm":
+        await query.edit_message_text(
+            f"Удалить все сохраненные настройки профиля?\n\n{PROFILE_DELETE_NOTICE}",
+            reply_markup=InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton(
+                            "Удалить профиль", callback_data="privacy:delete_profile"
+                        ),
+                        InlineKeyboardButton("Назад", callback_data="privacy:back"),
+                    ]
+                ]
+            ),
+        )
+        return PrivacyState.VIEWING
+    if action == "delete_profile":
+        service.clear_profile(user_id)
+        await query.edit_message_text(
+            f"Сохраненный профиль удален.\n\n{PROFILE_DELETE_NOTICE}\n{TELEGRAM_ACCESS_NOTICE}"
+        )
+        return PrivacyState.END
+
+    operations = {
+        "forget_name": lambda: service.clear_preferred_name(user_id),
+        "forget_timezone": lambda: service.clear_timezone(user_id),
+        "ask_email": lambda: service.clear_email(user_id),
+        "private_email": lambda: service.save_private_email_mode(user_id),
+    }
+    operation = operations.get(action)
+    if operation is not None:
+        operation()
+
+    profile = _load_profile(context, user_id)
+    await query.edit_message_text(
+        _privacy_summary(profile),
+        reply_markup=_privacy_keyboard(profile),
+    )
+    return PrivacyState.VIEWING
+
+
+async def privacy_enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Save a new preferred booking name."""
+    name = update.message.text.strip()
+    if not name:
+        await update.message.reply_text("Имя не может быть пустым. Попробуйте ещё раз:")
+        return PrivacyState.ENTERING_NAME
+    if len(name) > 100:
+        await update.message.reply_text("Имя слишком длинное. Введите до 100 символов:")
+        return PrivacyState.ENTERING_NAME
+
+    _profile_service(context).save_preferred_name(update.effective_user.id, name)
+    await _reply_with_profile(update, context)
+    return PrivacyState.VIEWING
+
+
+async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Save a timezone selected through an opaque numeric callback."""
+    query = update.callback_query
+    await query.answer()
+    try:
+        index = int(query.data.split(":", 1)[1])
+        if index < 0:
+            return PrivacyState.SELECTING_TIMEZONE
+        timezone_id = RUSSIAN_TIMEZONES[index][0]
+    except (IndexError, ValueError):
+        return PrivacyState.SELECTING_TIMEZONE
+
+    _profile_service(context).save_timezone(query.from_user.id, timezone_id)
+    profile = _load_profile(context, query.from_user.id)
+    await query.edit_message_text(
+        _privacy_summary(profile),
+        reply_markup=_privacy_keyboard(profile),
+    )
+    return PrivacyState.VIEWING
+
+
+async def privacy_enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Save a separately consented personal booking email."""
+    email = update.message.text.strip()
+    if "@" not in email or "." not in email.split("@")[-1]:
+        await update.message.reply_text("Некорректный email. Попробуйте ещё раз:")
+        return PrivacyState.ENTERING_EMAIL
+
+    _profile_service(context).save_email(update.effective_user.id, email)
+    await _reply_with_profile(update, context)
+    return PrivacyState.VIEWING
+
+
+async def _reply_with_profile(update, context) -> None:
+    profile = _load_profile(context, update.effective_user.id)
+    await update.message.reply_text(
+        _privacy_summary(profile),
+        reply_markup=_privacy_keyboard(profile),
+    )
+
+
+def _profile_service(context) -> UserPreferenceService:
+    return context.bot_data["user_preference_service"]
+
+
+def _load_profile(context, user_id: int):
+    try:
+        return _profile_service(context).get_profile(user_id)
+    except Exception:
+        logger.exception("Failed to load booking profile for privacy command user_id=%s", user_id)
+        return None
+
+
+def _privacy_summary(profile) -> str:
+    name = profile.preferred_name if profile and profile.preferred_name else "не сохранено"
+    timezone = profile.timezone if profile and profile.timezone else "не сохранен"
+    if profile is None or profile.email_mode == "ask":
+        email = "спрашивать каждый раз"
+    elif profile.email_mode == "private":
+        email = "без личного email"
+    else:
+        email = _mask_email(profile.email)
+
+    return (
+        "Сохраненные данные для записи:\n\n"
+        f"Имя: {name}\n"
+        f"Часовой пояс: {timezone}\n"
+        f"Email: {email}\n\n"
+        f"{PROFILE_DELETE_NOTICE}\n"
+        f"{TELEGRAM_ACCESS_NOTICE}"
+    )
+
+
+def _privacy_keyboard(profile) -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton("Изменить имя", callback_data="privacy:edit_name")],
+    ]
+    if profile and profile.preferred_name:
+        buttons[-1].append(InlineKeyboardButton("Забыть имя", callback_data="privacy:forget_name"))
+
+    buttons.append(
+        [InlineKeyboardButton("Изменить часовой пояс", callback_data="privacy:edit_timezone")]
+    )
+    if profile and profile.timezone:
+        buttons[-1].append(
+            InlineKeyboardButton("Забыть часовой пояс", callback_data="privacy:forget_timezone")
+        )
+
+    buttons.extend(
+        [
+            [InlineKeyboardButton("Сохранить email", callback_data="privacy:edit_email")],
+            [
+                InlineKeyboardButton("Без личного email", callback_data="privacy:private_email"),
+                InlineKeyboardButton("Спрашивать email", callback_data="privacy:ask_email"),
+            ],
+            [InlineKeyboardButton("Удалить весь профиль", callback_data="privacy:delete_confirm")],
+        ]
+    )
+    return InlineKeyboardMarkup(buttons)
+
+
+def _privacy_timezone_keyboard() -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton(label, callback_data=f"privacy_tz:{index}")]
+        for index, (_, label) in enumerate(RUSSIAN_TIMEZONES)
+    ]
+    buttons.append([InlineKeyboardButton("Назад", callback_data="privacy:back")])
+    return InlineKeyboardMarkup(buttons)
+
+
+def _mask_email(email: str | None) -> str:
+    if not email or "@" not in email:
+        return "сохранен"
+    local, domain = email.rsplit("@", 1)
+    first = local[:1] or "*"
+    return f"{first}***@{domain}"
+
+
+def create_privacy_conversation_handler() -> ConversationHandler:
+    """Create the /privacy profile-management conversation."""
+    return ConversationHandler(
+        entry_points=[CommandHandler("privacy", privacy_command)],
+        states={
+            PrivacyState.VIEWING: [
+                CallbackQueryHandler(privacy_callback, pattern="^privacy:"),
+            ],
+            PrivacyState.ENTERING_NAME: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, privacy_enter_name),
+            ],
+            PrivacyState.SELECTING_TIMEZONE: [
+                CallbackQueryHandler(privacy_select_timezone, pattern="^privacy_tz:"),
+                CallbackQueryHandler(privacy_callback, pattern="^privacy:back$"),
+            ],
+            PrivacyState.ENTERING_EMAIL: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, privacy_enter_email),
+            ],
+        },
+        fallbacks=[CommandHandler("privacy", privacy_command)],
+        allow_reentry=True,
+    )

--- a/app/handlers/privacy.py
+++ b/app/handlers/privacy.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from enum import IntEnum, auto
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.error import BadRequest
 from telegram.ext import (
     CallbackQueryHandler,
     CommandHandler,
@@ -16,7 +17,7 @@ from telegram.ext import (
 )
 
 from app.config import settings
-from app.constants import RUSSIAN_TIMEZONES
+from app.constants import MAX_EMAIL_LENGTH, MAX_NAME_LENGTH, RUSSIAN_TIMEZONES
 from app.services.user_preferences import UserPreferenceService
 
 logger = logging.getLogger(__name__)
@@ -66,29 +67,31 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     if action in PROFILE_VALUE_WRITE_ACTIONS and not _can_write_profile(context, user_id):
         _clear_pending_privacy_input(context)
-        await query.edit_message_text(PROFILE_WRITE_DENIED)
+        await _safe_edit_message_text(query, PROFILE_WRITE_DENIED)
         return PrivacyState.VIEWING
 
     if action == "edit_name":
         context.user_data[PENDING_PRIVACY_INPUT_KEY] = "name"
-        await query.edit_message_text("Введите имя, которое нужно запомнить:")
+        await _safe_edit_message_text(query, "Введите имя, которое нужно запомнить:")
         return PrivacyState.ENTERING_NAME
     if action == "edit_timezone":
         context.user_data[PENDING_PRIVACY_INPUT_KEY] = "timezone"
-        await query.edit_message_text(
+        await _safe_edit_message_text(
+            query,
             "Выберите часовой пояс, который нужно запомнить:",
             reply_markup=_privacy_timezone_keyboard(),
         )
         return PrivacyState.SELECTING_TIMEZONE
     if action == "edit_email":
         context.user_data[PENDING_PRIVACY_INPUT_KEY] = "email"
-        await query.edit_message_text("Введите email, который нужно запомнить:")
+        await _safe_edit_message_text(query, "Введите email, который нужно запомнить:")
         return PrivacyState.ENTERING_EMAIL
     if action == "back":
         _clear_pending_privacy_input(context)
     if action == "delete_confirm":
         _clear_pending_privacy_input(context)
-        await query.edit_message_text(
+        await _safe_edit_message_text(
+            query,
             f"Удалить все сохраненные настройки профиля?\n\n{PROFILE_DELETE_NOTICE}",
             reply_markup=InlineKeyboardMarkup(
                 [
@@ -109,12 +112,14 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             service.clear_profile(user_id)
         except Exception as error:
             _log_storage_failure("delete", user_id, error)
-            await query.edit_message_text(
+            await _safe_edit_message_text(
+                query,
                 "Не удалось удалить сохраненный профиль. Попробуйте позже.\n\n"
                 f"{PROFILE_DELETE_NOTICE}"
             )
             return PrivacyState.VIEWING
-        await query.edit_message_text(
+        await _safe_edit_message_text(
+            query,
             f"Сохраненный профиль удален.\n\n{PROFILE_DELETE_NOTICE}\n{TELEGRAM_ACCESS_NOTICE}"
         )
         return PrivacyState.END
@@ -132,13 +137,15 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             operation()
         except Exception as error:
             _log_storage_failure("update", user_id, error)
-            await query.edit_message_text(
+            await _safe_edit_message_text(
+                query,
                 "Не удалось изменить сохраненные данные. Попробуйте позже."
             )
             return PrivacyState.VIEWING
 
     profile = _load_profile(context, user_id)
-    await query.edit_message_text(
+    await _safe_edit_message_text(
+        query,
         _privacy_summary(profile),
         reply_markup=_privacy_keyboard(profile),
     )
@@ -161,8 +168,10 @@ async def privacy_enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if not name:
         await update.message.reply_text("Имя не может быть пустым. Попробуйте ещё раз:")
         return PrivacyState.ENTERING_NAME
-    if len(name) > 100:
-        await update.message.reply_text("Имя слишком длинное. Введите до 100 символов:")
+    if len(name) > MAX_NAME_LENGTH:
+        await update.message.reply_text(
+            f"Имя слишком длинное. Введите до {MAX_NAME_LENGTH} символов:"
+        )
         return PrivacyState.ENTERING_NAME
 
     try:
@@ -183,13 +192,14 @@ async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_
     query = update.callback_query
     await query.answer()
     if not _pending_input_matches(context, "timezone"):
-        await query.edit_message_text(
+        await _safe_edit_message_text(
+            query,
             "Редактирование часового пояса отменено. Используйте /privacy, чтобы начать снова."
         )
         return PrivacyState.END
     if not _can_write_profile(context, query.from_user.id):
         _clear_pending_privacy_input(context)
-        await query.edit_message_text(PROFILE_WRITE_DENIED)
+        await _safe_edit_message_text(query, PROFILE_WRITE_DENIED)
         return PrivacyState.END
 
     try:
@@ -204,11 +214,15 @@ async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_
         _profile_service(context).save_timezone(query.from_user.id, timezone_id)
     except Exception as error:
         _log_storage_failure("save_timezone", query.from_user.id, error)
-        await query.edit_message_text("Не удалось сохранить часовой пояс. Попробуйте позже.")
+        await _safe_edit_message_text(
+            query,
+            "Не удалось сохранить часовой пояс. Попробуйте позже.",
+        )
         return PrivacyState.SELECTING_TIMEZONE
     _clear_pending_privacy_input(context)
     profile = _load_profile(context, query.from_user.id)
-    await query.edit_message_text(
+    await _safe_edit_message_text(
+        query,
         _privacy_summary(profile),
         reply_markup=_privacy_keyboard(profile),
     )
@@ -228,6 +242,12 @@ async def privacy_enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE
         return PrivacyState.END
 
     email = update.message.text.strip()
+    if len(email) > MAX_EMAIL_LENGTH:
+        await update.message.reply_text(
+            f"Email слишком длинный. Введите до {MAX_EMAIL_LENGTH} символов:"
+        )
+        return PrivacyState.ENTERING_EMAIL
+
     if "@" not in email or "." not in email.split("@")[-1]:
         await update.message.reply_text("Некорректный email. Попробуйте ещё раз:")
         return PrivacyState.ENTERING_EMAIL
@@ -270,6 +290,16 @@ async def privacy_timeout(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return PrivacyState.END
 
 
+async def _safe_edit_message_text(query, text: str, reply_markup=None) -> None:
+    """Edit a privacy screen while tolerating Telegram's unchanged-content no-op."""
+    try:
+        await query.edit_message_text(text, reply_markup=reply_markup)
+    except BadRequest as error:
+        if "message is not modified" in str(error).lower():
+            return
+        raise
+
+
 async def _reply_with_profile(update, context) -> None:
     profile = _load_profile(context, update.effective_user.id)
     await update.message.reply_text(
@@ -278,8 +308,8 @@ async def _reply_with_profile(update, context) -> None:
     )
 
 
-def _profile_service(context) -> UserPreferenceService:
-    return context.bot_data["user_preference_service"]
+def _profile_service(context) -> UserPreferenceService | None:
+    return context.bot_data.get("user_preference_service")
 
 
 def _clear_pending_privacy_input(context) -> None:
@@ -307,8 +337,15 @@ def _can_write_profile(context, user_id: int) -> bool:
 
 
 def _load_profile(context, user_id: int):
+    service = _profile_service(context)
+    if service is None:
+        logger.error(
+            "Booking profile storage failure action=load user_id=%s error_type=ServiceMissing",
+            user_id,
+        )
+        return PROFILE_LOAD_FAILED
     try:
-        return _profile_service(context).get_profile(user_id)
+        return service.get_profile(user_id)
     except Exception as error:
         _log_storage_failure("load", user_id, error)
         return PROFILE_LOAD_FAILED

--- a/app/handlers/privacy.py
+++ b/app/handlers/privacy.py
@@ -40,7 +40,7 @@ PROFILE_VALUE_WRITE_ACTIONS = frozenset(
 class PrivacyState(IntEnum):
     """States for the /privacy profile-management conversation."""
 
-    VIEWING = auto()
+    VIEWING = 101
     ENTERING_NAME = auto()
     SELECTING_TIMEZONE = auto()
     ENTERING_EMAIL = auto()

--- a/app/handlers/privacy.py
+++ b/app/handlers/privacy.py
@@ -22,6 +22,7 @@ PROFILE_DELETE_NOTICE = "Удаление настроек не отменяет
 TELEGRAM_ACCESS_NOTICE = (
     "Данные доступа Telegram управляются отдельно и в этом разделе не изменяются."
 )
+PROFILE_LOAD_FAILED = object()
 
 
 class PrivacyState(IntEnum):
@@ -80,7 +81,15 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         )
         return PrivacyState.VIEWING
     if action == "delete_profile":
-        service.clear_profile(user_id)
+        try:
+            service.clear_profile(user_id)
+        except Exception as error:
+            _log_storage_failure("delete", user_id, error)
+            await query.edit_message_text(
+                "Не удалось удалить сохраненный профиль. Попробуйте позже.\n\n"
+                f"{PROFILE_DELETE_NOTICE}"
+            )
+            return PrivacyState.VIEWING
         await query.edit_message_text(
             f"Сохраненный профиль удален.\n\n{PROFILE_DELETE_NOTICE}\n{TELEGRAM_ACCESS_NOTICE}"
         )
@@ -94,7 +103,14 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     }
     operation = operations.get(action)
     if operation is not None:
-        operation()
+        try:
+            operation()
+        except Exception as error:
+            _log_storage_failure("update", user_id, error)
+            await query.edit_message_text(
+                "Не удалось изменить сохраненные данные. Попробуйте позже."
+            )
+            return PrivacyState.VIEWING
 
     profile = _load_profile(context, user_id)
     await query.edit_message_text(
@@ -114,7 +130,14 @@ async def privacy_enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE)
         await update.message.reply_text("Имя слишком длинное. Введите до 100 символов:")
         return PrivacyState.ENTERING_NAME
 
-    _profile_service(context).save_preferred_name(update.effective_user.id, name)
+    try:
+        _profile_service(context).save_preferred_name(update.effective_user.id, name)
+    except Exception as error:
+        _log_storage_failure("save_name", update.effective_user.id, error)
+        await update.message.reply_text(
+            "Не удалось сохранить имя. Попробуйте позже или вернитесь командой /privacy."
+        )
+        return PrivacyState.ENTERING_NAME
     await _reply_with_profile(update, context)
     return PrivacyState.VIEWING
 
@@ -131,7 +154,12 @@ async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_
     except (IndexError, ValueError):
         return PrivacyState.SELECTING_TIMEZONE
 
-    _profile_service(context).save_timezone(query.from_user.id, timezone_id)
+    try:
+        _profile_service(context).save_timezone(query.from_user.id, timezone_id)
+    except Exception as error:
+        _log_storage_failure("save_timezone", query.from_user.id, error)
+        await query.edit_message_text("Не удалось сохранить часовой пояс. Попробуйте позже.")
+        return PrivacyState.SELECTING_TIMEZONE
     profile = _load_profile(context, query.from_user.id)
     await query.edit_message_text(
         _privacy_summary(profile),
@@ -147,7 +175,14 @@ async def privacy_enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE
         await update.message.reply_text("Некорректный email. Попробуйте ещё раз:")
         return PrivacyState.ENTERING_EMAIL
 
-    _profile_service(context).save_email(update.effective_user.id, email)
+    try:
+        _profile_service(context).save_email(update.effective_user.id, email)
+    except Exception as error:
+        _log_storage_failure("save_email", update.effective_user.id, error)
+        await update.message.reply_text(
+            "Не удалось сохранить email. Попробуйте позже или вернитесь командой /privacy."
+        )
+        return PrivacyState.ENTERING_EMAIL
     await _reply_with_profile(update, context)
     return PrivacyState.VIEWING
 
@@ -167,12 +202,28 @@ def _profile_service(context) -> UserPreferenceService:
 def _load_profile(context, user_id: int):
     try:
         return _profile_service(context).get_profile(user_id)
-    except Exception:
-        logger.exception("Failed to load booking profile for privacy command user_id=%s", user_id)
-        return None
+    except Exception as error:
+        _log_storage_failure("load", user_id, error)
+        return PROFILE_LOAD_FAILED
+
+
+def _log_storage_failure(action: str, user_id: int, error: Exception) -> None:
+    logger.error(
+        "Booking profile storage failure action=%s user_id=%s error_type=%s",
+        action,
+        user_id,
+        type(error).__name__,
+    )
 
 
 def _privacy_summary(profile) -> str:
+    if profile is PROFILE_LOAD_FAILED:
+        return (
+            "Не удалось загрузить сохраненные данные. Попробуйте позже.\n\n"
+            f"{PROFILE_DELETE_NOTICE}\n"
+            f"{TELEGRAM_ACCESS_NOTICE}"
+        )
+
     name = profile.preferred_name if profile and profile.preferred_name else "не сохранено"
     timezone = profile.timezone if profile and profile.timezone else "не сохранен"
     if profile is None or profile.email_mode == "ask":
@@ -193,6 +244,11 @@ def _privacy_summary(profile) -> str:
 
 
 def _privacy_keyboard(profile) -> InlineKeyboardMarkup:
+    if profile is PROFILE_LOAD_FAILED:
+        return InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Попробовать снова", callback_data="privacy:back")]]
+        )
+
     buttons = [
         [InlineKeyboardButton("Изменить имя", callback_data="privacy:edit_name")],
     ]

--- a/app/handlers/privacy.py
+++ b/app/handlers/privacy.py
@@ -1,6 +1,7 @@
 """Reversible management of explicitly remembered booking profile fields."""
 
 import logging
+from datetime import timedelta
 from enum import IntEnum, auto
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -10,9 +11,11 @@ from telegram.ext import (
     ContextTypes,
     ConversationHandler,
     MessageHandler,
+    TypeHandler,
     filters,
 )
 
+from app.config import settings
 from app.constants import RUSSIAN_TIMEZONES
 from app.services.user_preferences import UserPreferenceService
 
@@ -23,6 +26,14 @@ TELEGRAM_ACCESS_NOTICE = (
     "Данные доступа Telegram управляются отдельно и в этом разделе не изменяются."
 )
 PROFILE_LOAD_FAILED = object()
+PENDING_PRIVACY_INPUT_KEY = "privacy_pending_input"
+PROFILE_WRITE_DENIED = (
+    "Сохранять новые данные могут только одобренные пользователи. "
+    "Ранее сохраненные данные по-прежнему можно просматривать и удалять через /privacy."
+)
+PROFILE_VALUE_WRITE_ACTIONS = frozenset(
+    {"edit_name", "edit_timezone", "edit_email", "private_email"}
+)
 
 
 class PrivacyState(IntEnum):
@@ -37,6 +48,7 @@ class PrivacyState(IntEnum):
 
 async def privacy_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Display remembered fields without requiring current whitelist access."""
+    _clear_pending_privacy_input(context)
     profile = _load_profile(context, update.effective_user.id)
     await update.message.reply_text(
         _privacy_summary(profile),
@@ -51,21 +63,31 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     await query.answer()
     action = query.data.split(":", 1)[1]
     user_id = query.from_user.id
-    service = _profile_service(context)
+
+    if action in PROFILE_VALUE_WRITE_ACTIONS and not _can_write_profile(context, user_id):
+        _clear_pending_privacy_input(context)
+        await query.edit_message_text(PROFILE_WRITE_DENIED)
+        return PrivacyState.VIEWING
 
     if action == "edit_name":
+        context.user_data[PENDING_PRIVACY_INPUT_KEY] = "name"
         await query.edit_message_text("Введите имя, которое нужно запомнить:")
         return PrivacyState.ENTERING_NAME
     if action == "edit_timezone":
+        context.user_data[PENDING_PRIVACY_INPUT_KEY] = "timezone"
         await query.edit_message_text(
             "Выберите часовой пояс, который нужно запомнить:",
             reply_markup=_privacy_timezone_keyboard(),
         )
         return PrivacyState.SELECTING_TIMEZONE
     if action == "edit_email":
+        context.user_data[PENDING_PRIVACY_INPUT_KEY] = "email"
         await query.edit_message_text("Введите email, который нужно запомнить:")
         return PrivacyState.ENTERING_EMAIL
+    if action == "back":
+        _clear_pending_privacy_input(context)
     if action == "delete_confirm":
+        _clear_pending_privacy_input(context)
         await query.edit_message_text(
             f"Удалить все сохраненные настройки профиля?\n\n{PROFILE_DELETE_NOTICE}",
             reply_markup=InlineKeyboardMarkup(
@@ -81,6 +103,8 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         )
         return PrivacyState.VIEWING
     if action == "delete_profile":
+        _clear_pending_privacy_input(context)
+        service = _profile_service(context)
         try:
             service.clear_profile(user_id)
         except Exception as error:
@@ -95,6 +119,7 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         )
         return PrivacyState.END
 
+    service = _profile_service(context)
     operations = {
         "forget_name": lambda: service.clear_preferred_name(user_id),
         "forget_timezone": lambda: service.clear_timezone(user_id),
@@ -122,6 +147,16 @@ async def privacy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
 async def privacy_enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Save a new preferred booking name."""
+    if not _pending_input_matches(context, "name"):
+        await update.message.reply_text(
+            "Редактирование сохраненного имени отменено. Используйте /privacy, чтобы начать снова."
+        )
+        return PrivacyState.END
+    if not _can_write_profile(context, update.effective_user.id):
+        _clear_pending_privacy_input(context)
+        await update.message.reply_text(PROFILE_WRITE_DENIED)
+        return PrivacyState.END
+
     name = update.message.text.strip()
     if not name:
         await update.message.reply_text("Имя не может быть пустым. Попробуйте ещё раз:")
@@ -138,6 +173,7 @@ async def privacy_enter_name(update: Update, context: ContextTypes.DEFAULT_TYPE)
             "Не удалось сохранить имя. Попробуйте позже или вернитесь командой /privacy."
         )
         return PrivacyState.ENTERING_NAME
+    _clear_pending_privacy_input(context)
     await _reply_with_profile(update, context)
     return PrivacyState.VIEWING
 
@@ -146,6 +182,16 @@ async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_
     """Save a timezone selected through an opaque numeric callback."""
     query = update.callback_query
     await query.answer()
+    if not _pending_input_matches(context, "timezone"):
+        await query.edit_message_text(
+            "Редактирование часового пояса отменено. Используйте /privacy, чтобы начать снова."
+        )
+        return PrivacyState.END
+    if not _can_write_profile(context, query.from_user.id):
+        _clear_pending_privacy_input(context)
+        await query.edit_message_text(PROFILE_WRITE_DENIED)
+        return PrivacyState.END
+
     try:
         index = int(query.data.split(":", 1)[1])
         if index < 0:
@@ -160,6 +206,7 @@ async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_
         _log_storage_failure("save_timezone", query.from_user.id, error)
         await query.edit_message_text("Не удалось сохранить часовой пояс. Попробуйте позже.")
         return PrivacyState.SELECTING_TIMEZONE
+    _clear_pending_privacy_input(context)
     profile = _load_profile(context, query.from_user.id)
     await query.edit_message_text(
         _privacy_summary(profile),
@@ -170,6 +217,16 @@ async def privacy_select_timezone(update: Update, context: ContextTypes.DEFAULT_
 
 async def privacy_enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Save a separately consented personal booking email."""
+    if not _pending_input_matches(context, "email"):
+        await update.message.reply_text(
+            "Редактирование сохраненного email отменено. Используйте /privacy, чтобы начать снова."
+        )
+        return PrivacyState.END
+    if not _can_write_profile(context, update.effective_user.id):
+        _clear_pending_privacy_input(context)
+        await update.message.reply_text(PROFILE_WRITE_DENIED)
+        return PrivacyState.END
+
     email = update.message.text.strip()
     if "@" not in email or "." not in email.split("@")[-1]:
         await update.message.reply_text("Некорректный email. Попробуйте ещё раз:")
@@ -183,8 +240,34 @@ async def privacy_enter_email(update: Update, context: ContextTypes.DEFAULT_TYPE
             "Не удалось сохранить email. Попробуйте позже или вернитесь командой /privacy."
         )
         return PrivacyState.ENTERING_EMAIL
+    _clear_pending_privacy_input(context)
     await _reply_with_profile(update, context)
     return PrivacyState.VIEWING
+
+
+async def invalidate_pending_privacy_input(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """Invalidate abandoned privacy input before another command is dispatched."""
+    _clear_pending_privacy_input(context)
+
+
+async def privacy_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Cancel pending privacy editing without changing remembered data."""
+    _clear_pending_privacy_input(context)
+    await update.effective_message.reply_text("Редактирование сохраненных данных отменено.")
+    return PrivacyState.END
+
+
+async def privacy_timeout(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Expire abandoned privacy editing so later text cannot be persisted."""
+    _clear_pending_privacy_input(context)
+    if update.effective_message:
+        await update.effective_message.reply_text(
+            "Сессия управления сохраненными данными истекла. Используйте /privacy, чтобы начать снова."
+        )
+    return PrivacyState.END
 
 
 async def _reply_with_profile(update, context) -> None:
@@ -197,6 +280,30 @@ async def _reply_with_profile(update, context) -> None:
 
 def _profile_service(context) -> UserPreferenceService:
     return context.bot_data["user_preference_service"]
+
+
+def _clear_pending_privacy_input(context) -> None:
+    context.user_data.pop(PENDING_PRIVACY_INPUT_KEY, None)
+
+
+def _pending_input_matches(context, expected: str) -> bool:
+    return context.user_data.get(PENDING_PRIVACY_INPUT_KEY) == expected
+
+
+def _can_write_profile(context, user_id: int) -> bool:
+    whitelist_service = context.bot_data.get("whitelist_service")
+    if whitelist_service is None:
+        logger.warning("whitelist_service missing in bot_data; denying profile write")
+        return False
+    try:
+        return whitelist_service.is_whitelisted(user_id)
+    except Exception as error:
+        logger.error(
+            "Failed to check profile write access for user_id=%s error_type=%s",
+            user_id,
+            type(error).__name__,
+        )
+        return False
 
 
 def _load_profile(context, user_id: int):
@@ -311,7 +418,15 @@ def create_privacy_conversation_handler() -> ConversationHandler:
             PrivacyState.ENTERING_EMAIL: [
                 MessageHandler(filters.TEXT & ~filters.COMMAND, privacy_enter_email),
             ],
+            ConversationHandler.TIMEOUT: [TypeHandler(Update, privacy_timeout)],
         },
-        fallbacks=[CommandHandler("privacy", privacy_command)],
+        fallbacks=[
+            CommandHandler("privacy", privacy_command),
+            CommandHandler("cancel", privacy_cancel),
+            MessageHandler(filters.COMMAND, privacy_cancel),
+        ],
         allow_reentry=True,
+        conversation_timeout=timedelta(
+            seconds=settings.booking_conversation_timeout_seconds
+        ),
     )

--- a/app/handlers/user_conversation.py
+++ b/app/handlers/user_conversation.py
@@ -1,0 +1,134 @@
+"""Mutually exclusive routing for booking and privacy conversations."""
+
+from datetime import timedelta
+
+from telegram import Update
+from telegram.ext import (
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    TypeHandler,
+    filters,
+)
+
+from app.config import settings
+from app.handlers.booking import (
+    _cancel_booking_timeout_reminder,
+    _clear_booking_scoped_state,
+    book_command,
+    booking_timeout,
+    create_booking_conversation_handler,
+)
+from app.handlers.booking import (
+    cancel as cancel_booking,
+)
+from app.handlers.privacy import (
+    create_privacy_conversation_handler,
+    invalidate_pending_privacy_input,
+    privacy_cancel,
+    privacy_command,
+    privacy_timeout,
+)
+
+ACTIVE_USER_CONVERSATION_KEY = "active_user_conversation"
+BOOKING_CONVERSATION = "booking"
+PRIVACY_CONVERSATION = "privacy"
+
+
+async def _book_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await invalidate_pending_privacy_input(update, context)
+    result = await book_command(update, context)
+    _record_active_conversation(context, BOOKING_CONVERSATION, result)
+    return result
+
+
+async def _privacy_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    if update.effective_user:
+        _cancel_booking_timeout_reminder(context, update.effective_user.id)
+    _clear_booking_scoped_state(context)
+    result = await privacy_command(update, context)
+    _record_active_conversation(context, PRIVACY_CONVERSATION, result)
+    return result
+
+
+async def _cancel_active_conversation(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> int:
+    active = context.user_data.get(ACTIVE_USER_CONVERSATION_KEY)
+    try:
+        if active == PRIVACY_CONVERSATION:
+            return await privacy_cancel(update, context)
+        return await cancel_booking(update, context)
+    finally:
+        context.user_data.pop(ACTIVE_USER_CONVERSATION_KEY, None)
+
+
+async def _cancel_for_other_command(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> int:
+    await _cancel_active_conversation(update, context)
+    await update.effective_message.reply_text(
+        "Предыдущий диалог завершен. Повторите команду."
+    )
+    return ConversationHandler.END
+
+
+async def _conversation_timeout(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> int:
+    active = context.user_data.get(ACTIVE_USER_CONVERSATION_KEY)
+    try:
+        if active == PRIVACY_CONVERSATION:
+            return await privacy_timeout(update, context)
+        return await booking_timeout(update, context)
+    finally:
+        context.user_data.pop(ACTIVE_USER_CONVERSATION_KEY, None)
+
+
+def _record_active_conversation(context, name: str, result: int) -> None:
+    if result == ConversationHandler.END:
+        context.user_data.pop(ACTIVE_USER_CONVERSATION_KEY, None)
+        return
+    context.user_data[ACTIVE_USER_CONVERSATION_KEY] = name
+
+
+def create_user_conversation_handler() -> ConversationHandler:
+    """Create one state machine so /book and /privacy replace each other."""
+    booking = create_booking_conversation_handler()
+    privacy = create_privacy_conversation_handler()
+    states = {
+        state: handlers
+        for state, handlers in booking.states.items()
+        if state != ConversationHandler.TIMEOUT
+    }
+    privacy_states = {
+        state: handlers
+        for state, handlers in privacy.states.items()
+        if state != ConversationHandler.TIMEOUT
+    }
+    if states.keys() & privacy_states.keys():
+        raise RuntimeError("Booking and privacy conversation states overlap")
+    states.update(privacy_states)
+    states[ConversationHandler.TIMEOUT] = [
+        TypeHandler(Update, _conversation_timeout)
+    ]
+
+    return ConversationHandler(
+        entry_points=[
+            CommandHandler("book", _book_entry),
+            CommandHandler("privacy", _privacy_entry),
+        ],
+        states=states,
+        fallbacks=[
+            CommandHandler("cancel", _cancel_active_conversation),
+            MessageHandler(filters.COMMAND, _cancel_for_other_command),
+        ],
+        allow_reentry=True,
+        conversation_timeout=timedelta(
+            seconds=settings.booking_conversation_timeout_seconds
+        ),
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.handlers import (
     create_cancel_booking_flow_handlers,
     create_privacy_conversation_handler,
     help_command,
+    invalidate_pending_privacy_input,
     pending_command,
     reject_command,
     start_command,
@@ -77,6 +78,10 @@ def create_application() -> Application:
     application.bot_data["calcom_client"] = CalComClient(api_key=settings.calcom_api_key)
 
     # Register handlers
+    application.add_handler(
+        MessageHandler(filters.COMMAND, invalidate_pending_privacy_input),
+        group=-1,
+    )
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("approve", approve_command))
     application.add_handler(CommandHandler("reject", reject_command))
@@ -85,8 +90,8 @@ def create_application() -> Application:
     application.add_handler(CommandHandler("setlimit", setlimit_command))
     application.add_handler(CommandHandler("removelimit", removelimit_command))
     application.add_handler(CommandHandler("limits", limits_command))
-    application.add_handler(create_privacy_conversation_handler())
     application.add_handler(create_booking_conversation_handler())
+    application.add_handler(create_privacy_conversation_handler())
     for handler in create_cancel_booking_flow_handlers():
         application.add_handler(handler)
     application.add_handler(

--- a/app/main.py
+++ b/app/main.py
@@ -58,7 +58,7 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
         logger.warning("Transient Telegram network error: %s", error)
         return
 
-    logger.error("Unhandled exception while processing update %r", update, exc_info=error)
+    logger.error("Unhandled exception while processing update", exc_info=error)
 
 
 def create_application() -> Application:

--- a/app/main.py
+++ b/app/main.py
@@ -18,9 +18,8 @@ from app.config import settings
 from app.database import db, run_migrations
 from app.handlers import (
     approve_command,
-    create_booking_conversation_handler,
     create_cancel_booking_flow_handlers,
-    create_privacy_conversation_handler,
+    create_user_conversation_handler,
     help_command,
     invalidate_pending_privacy_input,
     pending_command,
@@ -84,6 +83,7 @@ def create_application() -> Application:
         MessageHandler(filters.COMMAND, invalidate_pending_privacy_input),
         group=-1,
     )
+    application.add_handler(create_user_conversation_handler())
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("approve", approve_command))
     application.add_handler(CommandHandler("reject", reject_command))
@@ -92,8 +92,6 @@ def create_application() -> Application:
     application.add_handler(CommandHandler("setlimit", setlimit_command))
     application.add_handler(CommandHandler("removelimit", removelimit_command))
     application.add_handler(CommandHandler("limits", limits_command))
-    application.add_handler(create_booking_conversation_handler())
-    application.add_handler(create_privacy_conversation_handler())
     for handler in create_cancel_booking_flow_handlers():
         application.add_handler(handler)
     application.add_handler(

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import traceback
 
 from telegram import BotCommand
 from telegram.error import NetworkError
@@ -61,8 +62,9 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
         return
 
     logger.error(
-        "Unhandled exception while processing update error_type=%s",
+        "Unhandled exception while processing update error_type=%s traceback_frames=\n%s",
         type(error).__name__,
+        "".join(traceback.format_tb(error.__traceback__)).rstrip(),
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.handlers import (
     approve_command,
     create_booking_conversation_handler,
     create_cancel_booking_flow_handlers,
+    create_privacy_conversation_handler,
     help_command,
     pending_command,
     reject_command,
@@ -81,6 +82,7 @@ def create_application() -> Application:
     application.add_handler(CommandHandler("setlimit", setlimit_command))
     application.add_handler(CommandHandler("removelimit", removelimit_command))
     application.add_handler(CommandHandler("limits", limits_command))
+    application.add_handler(create_privacy_conversation_handler())
     application.add_handler(create_booking_conversation_handler())
     for handler in create_cancel_booking_flow_handlers():
         application.add_handler(handler)
@@ -99,6 +101,7 @@ def create_application() -> Application:
                 BotCommand("start", "Начать работу с ботом"),
                 BotCommand("book", "Записаться на встречу"),
                 BotCommand("cancel_booking", "Отменить запись"),
+                BotCommand("privacy", "Управлять сохраненными данными"),
                 BotCommand("help", "Показать список команд"),
             ]
         )
@@ -109,6 +112,7 @@ def create_application() -> Application:
                 BotCommand("start", "Начать работу с ботом"),
                 BotCommand("book", "Записаться на встречу"),
                 BotCommand("cancel_booking", "Отменить запись"),
+                BotCommand("privacy", "Управлять сохраненными данными"),
                 BotCommand("help", "Показать список команд"),
                 BotCommand("pending", "Список ожидающих запросов"),
                 BotCommand("setlimit", "Установить лимит длительности"),

--- a/app/main.py
+++ b/app/main.py
@@ -56,10 +56,13 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
     error = context.error
 
     if isinstance(error, NetworkError):
-        logger.warning("Transient Telegram network error: %s", error)
+        logger.warning("Transient Telegram network error type=%s", type(error).__name__)
         return
 
-    logger.error("Unhandled exception while processing update", exc_info=error)
+    logger.error(
+        "Unhandled exception while processing update error_type=%s",
+        type(error).__name__,
+    )
 
 
 def create_application() -> Application:

--- a/app/services/calcom_client.py
+++ b/app/services/calcom_client.py
@@ -171,10 +171,10 @@ class CalComClient:
         if cache_key in self._availability_cache:
             cached_at, data = self._availability_cache[cache_key]
             if time.time() - cached_at < self.cache_ttl:
-                logger.debug("Cache hit for availability: %s", cache_key)
+                logger.debug("Cache hit for availability")
                 return data
 
-        logger.debug("Cache miss for availability: %s", cache_key)
+        logger.debug("Cache miss for availability")
 
         # Fetch from API
         params = {
@@ -270,10 +270,9 @@ class CalComClient:
                 message = e.response.text
                 error_code = _extract_error_code(e.response)
                 logger.error(
-                    "Cal.com API error %d code=%s: %s",
+                    "Cal.com API error %d code=%s",
                     status_code,
                     error_code,
-                    message,
                 )
 
                 last_error = CalComAPIError(
@@ -285,7 +284,7 @@ class CalComClient:
                 sleep_seconds = self._retry_delay_seconds(e.response, delay_seconds)
             except httpx.RequestError as e:
                 message = str(e)
-                logger.error("Cal.com API network error: %s", message)
+                logger.error("Cal.com API network error type=%s", type(e).__name__)
 
                 last_error = CalComAPIError(status_code=0, message=message)
                 should_retry = True

--- a/app/services/user_preferences.py
+++ b/app/services/user_preferences.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from app.constants import SUPPORTED_TIMEZONE_IDS
+from app.constants import MAX_EMAIL_LENGTH, MAX_NAME_LENGTH, SUPPORTED_TIMEZONE_IDS
 from app.database import Database
 from app.database.models import UserProfile
 
@@ -36,6 +36,8 @@ class UserPreferenceService:
         value = preferred_name.strip()
         if not value:
             raise ValueError("Preferred name must not be blank")
+        if len(value) > MAX_NAME_LENGTH:
+            raise ValueError("Preferred name is too long")
         self._upsert(telegram_id, "preferred_name", value)
 
     def clear_preferred_name(self, telegram_id: int) -> None:
@@ -57,6 +59,8 @@ class UserPreferenceService:
         value = email.strip()
         if not value:
             raise ValueError("Email must not be blank")
+        if len(value) > MAX_EMAIL_LENGTH:
+            raise ValueError("Email is too long")
         now = self._now()
         self.db.execute_write(
             """

--- a/app/services/user_preferences.py
+++ b/app/services/user_preferences.py
@@ -1,19 +1,20 @@
-"""Service for persisted user profile preferences."""
+"""Service for explicitly consented booking profile preferences."""
 
 from datetime import datetime, timezone
 
+from app.constants import SUPPORTED_TIMEZONE_IDS
 from app.database import Database
-from app.database.models import UserPreference
+from app.database.models import UserProfile
 
 
 class UserPreferenceService:
-    """Store and retrieve user-level profile preferences."""
+    """Store, retrieve, and remove granular booking profile consent."""
 
     def __init__(self, db: Database):
         self.db = db
 
-    def get_timezone(self, telegram_id: int) -> UserPreference | None:
-        """Return the persisted timezone preference for a user, if present."""
+    def get_profile(self, telegram_id: int) -> UserProfile | None:
+        """Return the user's explicitly remembered booking profile, if any."""
         row = self.db.execute_one(
             "SELECT * FROM user_preferences WHERE telegram_id = ?",
             (telegram_id,),
@@ -21,22 +22,135 @@ class UserPreferenceService:
         if row is None:
             return None
 
-        return UserPreference(
+        return UserProfile(
             telegram_id=row["telegram_id"],
+            preferred_name=row["preferred_name"],
             timezone=row["timezone"],
+            email_mode=row["email_mode"],
+            email=row["email"],
             updated_at=datetime.fromisoformat(row["updated_at"]),
         )
 
-    def set_timezone(self, telegram_id: int, timezone_id: str) -> None:
-        """Create or update the user's selected timezone."""
-        now = datetime.now(timezone.utc).isoformat()
+    def save_preferred_name(self, telegram_id: int, preferred_name: str) -> None:
+        """Explicitly remember the user's preferred booking name."""
+        value = preferred_name.strip()
+        if not value:
+            raise ValueError("Preferred name must not be blank")
+        self._upsert(telegram_id, "preferred_name", value)
+
+    def clear_preferred_name(self, telegram_id: int) -> None:
+        """Forget only the preferred booking name."""
+        self._clear(telegram_id, "preferred_name")
+
+    def save_timezone(self, telegram_id: int, timezone_id: str) -> None:
+        """Explicitly remember a supported booking timezone."""
+        if timezone_id not in SUPPORTED_TIMEZONE_IDS:
+            raise ValueError(f"Unsupported timezone: {timezone_id}")
+        self._upsert(telegram_id, "timezone", timezone_id)
+
+    def clear_timezone(self, telegram_id: int) -> None:
+        """Forget only the booking timezone."""
+        self._clear(telegram_id, "timezone")
+
+    def save_email(self, telegram_id: int, email: str) -> None:
+        """Explicitly remember a personal booking email."""
+        value = email.strip()
+        if not value:
+            raise ValueError("Email must not be blank")
+        now = self._now()
         self.db.execute_write(
             """
-            INSERT INTO user_preferences (telegram_id, timezone, updated_at)
-            VALUES (?, ?, ?)
+            INSERT INTO user_preferences (
+                telegram_id, email_mode, email, updated_at
+            ) VALUES (?, 'saved', ?, ?)
             ON CONFLICT(telegram_id) DO UPDATE SET
-                timezone = excluded.timezone,
+                email_mode = 'saved',
+                email = excluded.email,
                 updated_at = excluded.updated_at
             """,
-            (telegram_id, timezone_id, now),
+            (telegram_id, value, now),
         )
+
+    def save_private_email_mode(self, telegram_id: int) -> None:
+        """Remember the preference to book without a personal email."""
+        now = self._now()
+        self.db.execute_write(
+            """
+            INSERT INTO user_preferences (telegram_id, email_mode, email, updated_at)
+            VALUES (?, 'private', NULL, ?)
+            ON CONFLICT(telegram_id) DO UPDATE SET
+                email_mode = 'private',
+                email = NULL,
+                updated_at = excluded.updated_at
+            """,
+            (telegram_id, now),
+        )
+
+    def clear_email(self, telegram_id: int) -> None:
+        """Forget email consent and return to asking on each booking."""
+        now = self._now()
+        with self.db.get_connection() as conn:
+            conn.execute(
+                """
+                UPDATE user_preferences
+                SET email_mode = 'ask', email = NULL, updated_at = ?
+                WHERE telegram_id = ?
+                """,
+                (now, telegram_id),
+            )
+            self._prune_empty_profile(conn, telegram_id)
+
+    def clear_profile(self, telegram_id: int) -> None:
+        """Delete every remembered booking profile field."""
+        self.db.execute_write(
+            "DELETE FROM user_preferences WHERE telegram_id = ?",
+            (telegram_id,),
+        )
+
+    def _upsert(self, telegram_id: int, column: str, value: str) -> None:
+        if column not in {"preferred_name", "timezone"}:
+            raise ValueError("Unsupported profile field")
+        now = self._now()
+        self.db.execute_write(
+            f"""
+            INSERT INTO user_preferences (telegram_id, {column}, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(telegram_id) DO UPDATE SET
+                {column} = excluded.{column},
+                updated_at = excluded.updated_at
+            """,
+            (telegram_id, value, now),
+        )
+
+    def _clear(self, telegram_id: int, column: str) -> None:
+        if column not in {"preferred_name", "timezone"}:
+            raise ValueError("Unsupported profile field")
+        now = self._now()
+        with self.db.get_connection() as conn:
+            conn.execute(
+                f"""
+                UPDATE user_preferences
+                SET {column} = NULL, updated_at = ?
+                WHERE telegram_id = ?
+                """,
+                (now, telegram_id),
+            )
+            self._prune_empty_profile(conn, telegram_id)
+
+    @staticmethod
+    def _prune_empty_profile(conn, telegram_id: int) -> None:
+        conn.execute(
+            """
+            DELETE FROM user_preferences
+            WHERE telegram_id = ?
+              AND preferred_name IS NULL
+              AND timezone IS NULL
+              AND email_mode = 'ask'
+              AND email IS NULL
+            """,
+            (telegram_id,),
+        )
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -48,13 +48,12 @@ from app.services.calcom_client import (
 )
 
 
-def _resolved_event_type(
-    duration_minutes: int, event_type_id: int = 42
-) -> ResolvedEventType:
+def _resolved_event_type(duration_minutes: int, event_type_id: int = 42) -> ResolvedEventType:
     return ResolvedEventType(
         event_type_id=event_type_id,
         duration_minutes=duration_minutes,
     )
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -223,8 +222,7 @@ class TestBuildDurationKeyboard:
         all_buttons = [btn for row in keyboard.inline_keyboard for btn in row]
 
         assert any(
-            btn.text == "Часовой пояс" and btn.callback_data == "change_tz"
-            for btn in all_buttons
+            btn.text == "Часовой пояс" and btn.callback_data == "change_tz" for btn in all_buttons
         )
 
 
@@ -367,13 +365,11 @@ class TestBookCommand:
         assert "reply_markup" in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_skips_timezone_selection_for_returning_user(
-        self, mock_update, mock_context
-    ):
+    async def test_skips_timezone_selection_for_returning_user(self, mock_update, mock_context):
         whitelist_service = MagicMock()
         whitelist_service.is_whitelisted.return_value = True
         preference_service = MagicMock()
-        preference_service.get_timezone.return_value = UserPreference(
+        preference_service.get_profile.return_value = UserPreference(
             telegram_id=12345,
             timezone="Europe/Moscow",
             updated_at=datetime.now(timezone.utc),
@@ -402,7 +398,7 @@ class TestBookCommand:
         whitelist_service = MagicMock()
         whitelist_service.is_whitelisted.return_value = True
         preference_service = MagicMock()
-        preference_service.get_timezone.return_value = UserPreference(
+        preference_service.get_profile.return_value = UserPreference(
             telegram_id=12345,
             timezone="Europe/Moscow",
             updated_at=datetime.now(timezone.utc),
@@ -429,13 +425,13 @@ class TestBookCommand:
         assert "Загружаю" in mock_update.message.reply_text.call_args.args[0]
         sent_message.edit_text.assert_awaited_once()
         final_text = sent_message.edit_text.call_args.args[0]
-        assert "Используем сохраненный часовой пояс: Europe/Moscow" in final_text
+        assert "Часовой пояс: Europe/Moscow" in final_text
         assert "Доступное время" in final_text
 
     @pytest.mark.asyncio
     async def test_invalid_saved_timezone_falls_back_to_picker(self, mock_update, mock_context):
         preference_service = MagicMock()
-        preference_service.get_timezone.return_value = UserPreference(
+        preference_service.get_profile.return_value = UserPreference(
             telegram_id=12345,
             timezone="Europe/Removed",
             updated_at=datetime.now(timezone.utc),
@@ -451,12 +447,12 @@ class TestBookCommand:
         callback_data = [
             button.callback_data for row in reply_markup.inline_keyboard for button in row
         ]
-        assert "tz:Europe/Moscow" in callback_data
+        assert "tz:1" in callback_data
 
     @pytest.mark.asyncio
     async def test_preference_load_failure_falls_back_to_picker(self, mock_update, mock_context):
         preference_service = MagicMock()
-        preference_service.get_timezone.side_effect = RuntimeError("database unavailable")
+        preference_service.get_profile.side_effect = RuntimeError("database unavailable")
         mock_context.bot_data["whitelist_service"].is_whitelisted.return_value = True
         mock_context.bot_data["user_preference_service"] = preference_service
 
@@ -466,14 +462,14 @@ class TestBookCommand:
         assert "timezone" not in mock_context.user_data
 
     @pytest.mark.asyncio
-    async def test_returning_user_can_change_and_persist_timezone(
+    async def test_returning_user_can_change_timezone_without_automatic_persistence(
         self,
         mock_update,
         mock_update_with_query,
         mock_context,
     ):
         preference_service = MagicMock()
-        preference_service.get_timezone.return_value = UserPreference(
+        preference_service.get_profile.return_value = UserPreference(
             telegram_id=12345,
             timezone="Europe/Moscow",
             updated_at=datetime.now(timezone.utc),
@@ -493,7 +489,7 @@ class TestBookCommand:
 
         assert result == BookingState.SELECTING_DURATION
         assert mock_context.user_data["timezone"] == "Asia/Yekaterinburg"
-        preference_service.set_timezone.assert_called_once_with(12345, "Asia/Yekaterinburg")
+        preference_service.save_timezone.assert_not_called()
 
 
 class TestSelectTimezone:
@@ -512,7 +508,7 @@ class TestSelectTimezone:
         assert mock_context.user_data["timezone"] == "Europe/Moscow"
 
     @pytest.mark.asyncio
-    async def test_persists_selected_timezone(
+    async def test_does_not_automatically_persist_selected_timezone(
         self, mock_update_with_query, mock_context, mock_calcom_client
     ):
         preference_service = MagicMock()
@@ -525,7 +521,7 @@ class TestSelectTimezone:
 
         await select_timezone(mock_update_with_query, mock_context)
 
-        preference_service.set_timezone.assert_called_once_with(12345, "Europe/Moscow")
+        preference_service.save_timezone.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_does_not_rewrite_unchanged_timezone(
@@ -542,14 +538,13 @@ class TestSelectTimezone:
 
         await select_timezone(mock_update_with_query, mock_context)
 
-        preference_service.set_timezone.assert_not_called()
+        preference_service.save_timezone.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_preference_write_failure_does_not_block_booking(
+    async def test_timezone_selection_does_not_touch_profile_service(
         self, mock_update_with_query, mock_context, mock_calcom_client
     ):
         preference_service = MagicMock()
-        preference_service.set_timezone.side_effect = RuntimeError("database unavailable")
         mock_update_with_query.callback_query.data = "tz:Europe/Moscow"
         mock_context.bot_data = {
             "calcom_client": mock_calcom_client,
@@ -560,6 +555,7 @@ class TestSelectTimezone:
 
         assert result == BookingState.SELECTING_DURATION
         assert mock_context.user_data["timezone"] == "Europe/Moscow"
+        assert preference_service.mock_calls == []
 
     @pytest.mark.asyncio
     async def test_returns_selecting_duration_when_no_limit(
@@ -758,7 +754,7 @@ class TestEmailDecision:
         assert mock_context.user_data.get("email") is None
 
     @pytest.mark.asyncio
-    async def test_no_returns_confirming(self, mock_update_with_query, mock_context):
+    async def test_no_returns_remembering_profile(self, mock_update_with_query, mock_context):
         mock_update_with_query.callback_query.data = "email_no"
         mock_context.user_data = {
             "name": "Alice",
@@ -769,7 +765,7 @@ class TestEmailDecision:
 
         result = await email_decision(mock_update_with_query, mock_context)
 
-        assert result == BookingState.CONFIRMING
+        assert result == BookingState.REMEMBERING_PROFILE
 
 
 class TestEnterEmail:
@@ -788,7 +784,7 @@ class TestEnterEmail:
         assert mock_context.user_data["email"] == "alice@example.com"
 
     @pytest.mark.asyncio
-    async def test_returns_confirming(self, mock_update, mock_context):
+    async def test_returns_remembering_profile(self, mock_update, mock_context):
         mock_update.message.text = "alice@example.com"
         mock_context.user_data = {
             "name": "Alice",
@@ -799,7 +795,7 @@ class TestEnterEmail:
 
         result = await enter_email(mock_update, mock_context)
 
-        assert result == BookingState.CONFIRMING
+        assert result == BookingState.REMEMBERING_PROFILE
 
     @pytest.mark.asyncio
     async def test_shows_confirmation(self, mock_update, mock_context):
@@ -1152,11 +1148,7 @@ class TestConfirmBooking:
         keyboard = mock_update_with_query.callback_query.edit_message_text.call_args.kwargs[
             "reply_markup"
         ]
-        callbacks = {
-            button.callback_data
-            for row in keyboard.inline_keyboard
-            for button in row
-        }
+        callbacks = {button.callback_data for row in keyboard.inline_keyboard for button in row}
         assert callbacks == {"email_yes", "cancel"}
 
     @pytest.mark.asyncio

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -827,6 +827,28 @@ class TestEnterEmail:
         assert "email" not in mock_context.user_data
 
     @pytest.mark.asyncio
+    async def test_rejects_email_longer_than_254_characters(
+        self,
+        mock_update,
+        mock_context,
+    ):
+        mock_update.message.text = (
+            f"{'a' * (255 - len('@example.com'))}@example.com"
+        )
+        mock_context.user_data = {
+            "name": "Alice",
+            "selected_date": "2026-01-06",
+            "selected_time": "2026-01-06T10:00:00.000+03:00",
+            "timezone": "Europe/Moscow",
+        }
+
+        result = await enter_email(mock_update, mock_context)
+
+        assert result == BookingState.ENTERING_EMAIL
+        assert "email" not in mock_context.user_data
+        assert "254" in mock_update.message.reply_text.call_args.args[0]
+
+    @pytest.mark.asyncio
     async def test_rejects_invalid_email_no_dot_in_domain(self, mock_update, mock_context):
         mock_update.message.text = "user@localhost"
         mock_context.user_data = {

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1129,11 +1129,9 @@ class TestConfirmBooking:
             mock_settings.calcom_event_type_id = 42
             await confirm_booking(mock_update_with_query, mock_context)
 
-        mock_context.bot_data["booking_service"].save_booking.assert_called_once_with(
-            12345,
-            booking_response,
-            internal_ref=mock_context.user_data["internal_ref"],
-        )
+        save_call = mock_context.bot_data["booking_service"].save_booking.call_args
+        assert save_call.args == (12345, booking_response)
+        assert save_call.kwargs["internal_ref"].startswith("tbk_")
 
     @pytest.mark.asyncio
     async def test_uses_configured_privacy_email_and_opaque_reference_when_none(

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1206,6 +1206,7 @@ class TestConfirmBooking:
     @pytest.mark.asyncio
     async def test_rejected_personal_email_returns_to_email_entry(
         self,
+        mock_update,
         mock_update_with_query,
         mock_context,
         mock_calcom_client,
@@ -1214,6 +1215,8 @@ class TestConfirmBooking:
         mock_context.user_data = {
             "name": "Alice",
             "email": "rejected@example.com",
+            "email_mode": "saved",
+            "remembered_profile_fields": {"email"},
             "selected_date": "2026-01-06",
             "selected_time": "2026-01-06T10:00:00.000+03:00",
             "timezone": "Europe/Moscow",
@@ -1230,8 +1233,21 @@ class TestConfirmBooking:
 
         assert result == BookingState.ENTERING_EMAIL
         assert "email" not in mock_context.user_data
+        assert "email" not in mock_context.user_data["remembered_profile_fields"]
         message = mock_update_with_query.callback_query.edit_message_text.call_args.args[0]
         assert "не принимает этот email" in message
+
+        mock_update.message.text = "replacement@example.com"
+        result = await enter_email(mock_update, mock_context)
+
+        assert result == BookingState.REMEMBERING_PROFILE
+        keyboard = mock_update.message.reply_text.call_args.kwargs["reply_markup"]
+        callbacks = {
+            button.callback_data
+            for row in keyboard.inline_keyboard
+            for button in row
+        }
+        assert "remember:email" in callbacks
 
     @pytest.mark.asyncio
     async def test_handles_409_conflict(

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1065,6 +1065,34 @@ class TestConfirmBooking:
         assert result == ConversationHandler.END
 
     @pytest.mark.asyncio
+    async def test_success_clears_booking_scoped_data_but_keeps_unrelated_state(
+        self,
+        mock_update_with_query,
+        mock_context,
+        mock_calcom_client,
+        user_data_ready,
+        booking_response,
+    ):
+        mock_update_with_query.callback_query.data = "confirm"
+        mock_context.user_data = {
+            **user_data_ready,
+            "remembered_profile_fields": {"name", "timezone", "email"},
+            "active_user_conversation": "booking",
+            "unrelated": "keep",
+        }
+        mock_calcom_client.create_booking.return_value = booking_response
+
+        with patch("app.handlers.booking.settings") as mock_settings:
+            mock_settings.resolve_event_type.side_effect = _resolved_event_type
+            result = await confirm_booking(
+                mock_update_with_query,
+                mock_context,
+            )
+
+        assert result == ConversationHandler.END
+        assert mock_context.user_data == {"unrelated": "keep"}
+
+    @pytest.mark.asyncio
     async def test_shows_success_confirmation(
         self,
         mock_update_with_query,

--- a/tests/test_booking_profile.py
+++ b/tests/test_booking_profile.py
@@ -1,0 +1,228 @@
+"""Consent-aware booking profile regressions."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.database import Database
+from app.database.migrations import initialize_schema
+from app.handlers import booking
+from app.services.user_preferences import UserPreferenceService
+
+
+def _context(*, profile_service=None):
+    context = MagicMock()
+    context.user_data = {}
+    context.job_queue = None
+    context.bot_data = {
+        "whitelist_service": MagicMock(),
+        "calcom_client": AsyncMock(),
+    }
+    context.bot_data["whitelist_service"].is_whitelisted.return_value = True
+    if profile_service is not None:
+        context.bot_data["user_preference_service"] = profile_service
+    return context
+
+
+def _message_update(user_id=12345):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message = AsyncMock()
+    update.message.reply_text = AsyncMock()
+    update.callback_query = None
+    return update
+
+
+def _callback_update(data, user_id=12345):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message = None
+    update.callback_query = AsyncMock()
+    update.callback_query.data = data
+    update.callback_query.from_user.id = user_id
+    update.callback_query.answer = AsyncMock()
+    update.callback_query.edit_message_text = AsyncMock()
+    update.callback_query.message = AsyncMock()
+    return update
+
+
+def _ready_booking_data(**overrides):
+    data = {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "email_mode": "saved",
+        "selected_date": "2026-01-06",
+        "selected_time": "2026-01-06T10:00:00.000+03:00",
+        "timezone": "Europe/Moscow",
+        "duration": 30,
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.asyncio
+async def test_selecting_timezone_is_booking_scoped_until_remembered():
+    profile_service = MagicMock()
+    context = _context(profile_service=profile_service)
+    update = _callback_update("tz:3")
+
+    result = await booking.select_timezone(update, context)
+
+    assert result == booking.BookingState.SELECTING_DURATION
+    assert context.user_data["timezone"] == "Europe/Moscow"
+    profile_service.save_timezone.assert_not_called()
+    profile_service.set_timezone.assert_not_called()
+
+
+def test_timezone_callbacks_are_opaque_and_contain_no_profile_values():
+    keyboard = booking.build_timezone_keyboard()
+    callback_data = [
+        button.callback_data
+        for row in keyboard.inline_keyboard
+        for button in row
+        if button.callback_data != "cancel"
+    ]
+
+    assert callback_data == [f"tz:{index}" for index in range(11)]
+    assert not any("/" in value for value in callback_data)
+
+
+@pytest.mark.asyncio
+async def test_remembered_profile_is_reused_after_service_restart(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    first_service = UserPreferenceService(db)
+    first_service.save_preferred_name(12345, "Alice")
+    first_service.save_timezone(12345, "Europe/Moscow")
+    first_service.save_email(12345, "alice@example.com")
+
+    restarted_service = UserPreferenceService(db)
+    context = _context(profile_service=restarted_service)
+    update = _message_update()
+
+    result = await booking.book_command(update, context)
+
+    assert result == booking.BookingState.SELECTING_DURATION
+    assert context.user_data["name"] == "Alice"
+    assert context.user_data["timezone"] == "Europe/Moscow"
+    assert context.user_data["email"] == "alice@example.com"
+    assert context.user_data["email_mode"] == "saved"
+    message = update.message.reply_text.call_args.args[0]
+    assert "Alice" in message
+    assert "Europe/Moscow" in message
+    assert "сохран" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_saved_name_and_email_skip_repeated_prompts_after_slot():
+    context = _context()
+    context.user_data = _ready_booking_data()
+    update = _callback_update("slot:2026-01-06:2026-01-06T10:00:00.000+03:00")
+
+    result = await booking.select_slot(update, context)
+
+    assert result == booking.BookingState.REMEMBERING_PROFILE
+    message = update.callback_query.edit_message_text.call_args.args[0]
+    assert "сохран" in message.lower()
+    assert "имя" in message.lower()
+    assert "email" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_private_email_choice_opens_granular_remembering_screen():
+    context = _context()
+    context.user_data = _ready_booking_data(email=None, email_mode="private")
+    update = _callback_update("email_no")
+
+    result = await booking.email_decision(update, context)
+
+    assert result == booking.BookingState.REMEMBERING_PROFILE
+    keyboard = update.callback_query.edit_message_text.call_args.kwargs["reply_markup"]
+    callbacks = {
+        button.callback_data for row in keyboard.inline_keyboard for button in row
+    }
+    assert callbacks == {
+        "remember:name",
+        "remember:timezone",
+        "remember:private",
+        "remember:save",
+        "remember:none",
+    }
+
+
+@pytest.mark.asyncio
+async def test_remembering_saves_only_explicitly_selected_fields():
+    profile_service = MagicMock()
+    context = _context(profile_service=profile_service)
+    context.user_data = _ready_booking_data()
+    update = _callback_update("remember:name")
+
+    await booking.remember_profile_choice(update, context)
+    update.callback_query.data = "remember:timezone"
+    await booking.remember_profile_choice(update, context)
+    update.callback_query.data = "remember:save"
+    result = await booking.remember_profile_choice(update, context)
+
+    assert result == booking.BookingState.CONFIRMING
+    profile_service.save_preferred_name.assert_called_once_with(12345, "Alice")
+    profile_service.save_timezone.assert_called_once_with(12345, "Europe/Moscow")
+    profile_service.save_email.assert_not_called()
+    profile_service.save_private_email_mode.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_nothing_keeps_values_transient_and_shows_confirmation():
+    profile_service = MagicMock()
+    context = _context(profile_service=profile_service)
+    context.user_data = _ready_booking_data()
+    update = _callback_update("remember:none")
+
+    result = await booking.remember_profile_choice(update, context)
+
+    assert result == booking.BookingState.CONFIRMING
+    assert profile_service.mock_calls == []
+    message = update.callback_query.edit_message_text.call_args.args[0]
+    assert "Alice" in message
+    assert "alice@example.com" in message
+    keyboard = update.callback_query.edit_message_text.call_args.kwargs["reply_markup"]
+    assert any(
+        button.text == "Изменить данные" and button.callback_data == "edit:data"
+        for row in keyboard.inline_keyboard
+        for button in row
+    )
+
+
+def test_confirmation_always_shows_effective_private_booking_details():
+    text = booking._build_confirmation_text(
+        _ready_booking_data(email=None, email_mode="private")
+    )
+
+    assert "Alice" in text
+    assert "Europe/Moscow" in text
+    assert "Email: без личного email" in text
+
+
+@pytest.mark.asyncio
+async def test_change_controls_use_opaque_callbacks():
+    context = _context()
+    context.user_data = _ready_booking_data()
+    update = _callback_update("edit:data")
+
+    result = await booking.edit_booking_data(update, context)
+
+    assert result == booking.BookingState.CONFIRMING
+    keyboard = update.callback_query.edit_message_text.call_args.kwargs["reply_markup"]
+    callbacks = {
+        button.callback_data for row in keyboard.inline_keyboard for button in row
+    }
+    assert callbacks == {
+        "edit:name",
+        "edit:timezone",
+        "edit:email",
+        "edit:private",
+        "edit:back",
+    }
+    serialized = " ".join(callbacks)
+    assert "Alice" not in serialized
+    assert "Europe/Moscow" not in serialized
+    assert "alice@example.com" not in serialized

--- a/tests/test_booking_profile.py
+++ b/tests/test_booking_profile.py
@@ -203,6 +203,38 @@ async def test_editing_saved_field_makes_new_value_selectable_for_consent():
 
 
 @pytest.mark.asyncio
+async def test_editing_timezone_discards_slot_and_requires_reselection(
+    monkeypatch,
+):
+    context = _context()
+    context.user_data = _ready_booking_data(
+        edit_field="timezone",
+        remembered_profile_fields={"name", "email"},
+    )
+    update = _callback_update("tz:3")
+    show_availability = AsyncMock(
+        return_value=booking.BookingState.VIEWING_AVAILABILITY
+    )
+    monkeypatch.setattr(
+        booking,
+        "_show_availability",
+        show_availability,
+    )
+
+    result = await booking.select_timezone(update, context)
+
+    assert result == booking.BookingState.VIEWING_AVAILABILITY
+    assert context.user_data["timezone"] == "Asia/Yekaterinburg"
+    assert "selected_date" not in context.user_data
+    assert "selected_time" not in context.user_data
+    show_availability.assert_awaited_once_with(
+        update.callback_query,
+        context,
+        offset_days=0,
+    )
+
+
+@pytest.mark.asyncio
 async def test_already_remembered_status_does_not_write_profile():
     profile_service = MagicMock()
     context = _context(profile_service=profile_service)

--- a/tests/test_booking_profile.py
+++ b/tests/test_booking_profile.py
@@ -145,7 +145,76 @@ async def test_private_email_choice_opens_granular_remembering_screen():
         "remember:private",
         "remember:save",
         "remember:none",
+        "cancel",
     }
+
+
+@pytest.mark.asyncio
+async def test_saved_profile_fields_are_shown_as_already_remembered(
+    temp_db_path,
+):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    profile_service = UserPreferenceService(db)
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_email(12345, "alice@example.com")
+    context = _context(profile_service=profile_service)
+
+    await booking.book_command(_message_update(), context)
+    update = _callback_update(
+        "slot:2026-01-06:2026-01-06T10:00:00.000+03:00"
+    )
+    result = await booking.select_slot(update, context)
+
+    assert result == booking.BookingState.REMEMBERING_PROFILE
+    keyboard = update.callback_query.edit_message_text.call_args.kwargs[
+        "reply_markup"
+    ]
+    buttons = [button for row in keyboard.inline_keyboard for button in row]
+    remembered_buttons = [
+        button for button in buttons if "уже сохранено" in button.text.lower()
+    ]
+    assert len(remembered_buttons) == 3
+    assert all(button.text.startswith("✓ ") for button in remembered_buttons)
+    assert all(button.callback_data == "remember:kept" for button in remembered_buttons)
+    assert not {
+        "remember:name",
+        "remember:timezone",
+        "remember:email",
+    } & {button.callback_data for button in buttons}
+
+
+@pytest.mark.asyncio
+async def test_editing_saved_field_makes_new_value_selectable_for_consent():
+    context = _context()
+    context.user_data = _ready_booking_data(
+        remembered_profile_fields={"name", "timezone", "email"}
+    )
+    update = _callback_update("edit:name")
+
+    result = await booking.edit_booking_field(update, context)
+
+    assert result == booking.BookingState.ENTERING_NAME
+    assert context.user_data["remembered_profile_fields"] == {
+        "timezone",
+        "email",
+    }
+
+
+@pytest.mark.asyncio
+async def test_already_remembered_status_does_not_write_profile():
+    profile_service = MagicMock()
+    context = _context(profile_service=profile_service)
+    context.user_data = _ready_booking_data(
+        remembered_profile_fields={"name", "timezone", "email"}
+    )
+    update = _callback_update("remember:kept")
+
+    result = await booking.remember_profile_choice(update, context)
+
+    assert result == booking.BookingState.REMEMBERING_PROFILE
+    assert profile_service.mock_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_booking_profile.py
+++ b/tests/test_booking_profile.py
@@ -64,7 +64,7 @@ def _ready_booking_data(**overrides):
 async def test_selecting_timezone_is_booking_scoped_until_remembered():
     profile_service = MagicMock()
     context = _context(profile_service=profile_service)
-    update = _callback_update("tz:3")
+    update = _callback_update("tz:1")
 
     result = await booking.select_timezone(update, context)
 
@@ -138,9 +138,7 @@ async def test_private_email_choice_opens_granular_remembering_screen():
 
     assert result == booking.BookingState.REMEMBERING_PROFILE
     keyboard = update.callback_query.edit_message_text.call_args.kwargs["reply_markup"]
-    callbacks = {
-        button.callback_data for row in keyboard.inline_keyboard for button in row
-    }
+    callbacks = {button.callback_data for row in keyboard.inline_keyboard for button in row}
     assert callbacks == {
         "remember:name",
         "remember:timezone",
@@ -193,9 +191,7 @@ async def test_save_nothing_keeps_values_transient_and_shows_confirmation():
 
 
 def test_confirmation_always_shows_effective_private_booking_details():
-    text = booking._build_confirmation_text(
-        _ready_booking_data(email=None, email_mode="private")
-    )
+    text = booking._build_confirmation_text(_ready_booking_data(email=None, email_mode="private"))
 
     assert "Alice" in text
     assert "Europe/Moscow" in text
@@ -212,9 +208,7 @@ async def test_change_controls_use_opaque_callbacks():
 
     assert result == booking.BookingState.CONFIRMING
     keyboard = update.callback_query.edit_message_text.call_args.kwargs["reply_markup"]
-    callbacks = {
-        button.callback_data for row in keyboard.inline_keyboard for button in row
-    }
+    callbacks = {button.callback_data for row in keyboard.inline_keyboard for button in row}
     assert callbacks == {
         "edit:name",
         "edit:timezone",

--- a/tests/test_booking_profile.py
+++ b/tests/test_booking_profile.py
@@ -220,3 +220,45 @@ async def test_change_controls_use_opaque_callbacks():
     assert "Alice" not in serialized
     assert "Europe/Moscow" not in serialized
     assert "alice@example.com" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_profile_save_failure_keeps_booking_usable_without_false_success(
+    caplog,
+):
+    private_values = "Alice Europe/Moscow alice@example.com"
+    profile_service = MagicMock()
+    profile_service.save_preferred_name.side_effect = RuntimeError(private_values)
+    context = _context(profile_service=profile_service)
+    context.user_data = _ready_booking_data()
+    update = _callback_update("remember:name")
+    caplog.set_level("ERROR")
+
+    await booking.remember_profile_choice(update, context)
+    update.callback_query.data = "remember:save"
+    result = await booking.remember_profile_choice(update, context)
+
+    assert result == booking.BookingState.CONFIRMING
+    response = update.callback_query.edit_message_text.call_args.args[0]
+    assert "Не все выбранные данные удалось сохранить" in response
+    assert "Сохранено для следующих записей" not in response
+    assert private_values not in caplog.text
+    assert "Alice" not in caplog.text
+    assert "Europe/Moscow" not in caplog.text
+    assert "alice@example.com" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_profile_load_failure_falls_back_without_logging_private_values(caplog):
+    private_values = "Alice Europe/Moscow alice@example.com"
+    profile_service = MagicMock()
+    profile_service.get_profile.side_effect = RuntimeError(private_values)
+    context = _context(profile_service=profile_service)
+    update = _message_update()
+    caplog.set_level("ERROR")
+
+    result = await booking.book_command(update, context)
+
+    assert result == booking.BookingState.SELECTING_TIMEZONE
+    assert private_values not in caplog.text
+    assert "alice@example.com" not in caplog.text

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -159,9 +159,7 @@ class TestCalComClient:
             },
         }
 
-        with patch.object(
-            client, "_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             result = await client.get_availability(
@@ -270,9 +268,7 @@ class TestCalComClient:
             },
         }
 
-        with patch.object(
-            client, "_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             # First call
@@ -305,9 +301,7 @@ class TestCalComClient:
             "data": {"slots": {}},
         }
 
-        with patch.object(
-            client, "_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             await client.get_availability(
@@ -340,9 +334,7 @@ class TestCalComClient:
             "data": {"slots": {}},
         }
 
-        with patch.object(
-            client, "_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             await client.get_availability(
@@ -382,9 +374,7 @@ class TestCalComClient:
             },
         }
 
-        with patch.object(
-            client, "_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = mock_response
 
             request = BookingRequest(
@@ -454,9 +444,7 @@ class TestCalComClient:
             },
         }
 
-        with patch.object(
-            client, "_request", new_callable=AsyncMock
-        ) as mock_request:
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             # First call: get availability (populates cache)
             mock_request.return_value = avail_response
             await client.get_availability(
@@ -591,9 +579,7 @@ class TestCalComClientRetry:
         assert exc_info.value.code == "email_domain_cannot_receive_mail"
 
     @pytest.mark.asyncio
-    async def test_error_log_does_not_expose_response_profile_values(
-        self, client, caplog
-    ):
+    async def test_error_log_does_not_expose_response_profile_values(self, client, caplog):
         private_values = "Alice Europe/Moscow alice@example.com"
         response = httpx.Response(
             400,
@@ -656,12 +642,8 @@ class TestCalComClientRetry:
     @pytest.mark.asyncio
     async def test_retries_retryable_status_then_succeeds(self, client):
         with (
-            patch.object(
-                client._client, "request", new_callable=AsyncMock
-            ) as mock_request,
-            patch(
-                "app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock
-            ) as mock_sleep,
+            patch.object(client._client, "request", new_callable=AsyncMock) as mock_request,
+            patch("app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
             mock_request.side_effect = [
                 self._http_status_error(429, "rate limited"),
@@ -764,12 +746,8 @@ class TestCalComClientRetry:
     @pytest.mark.asyncio
     async def test_does_not_retry_non_retryable_status(self, client):
         with (
-            patch.object(
-                client._client, "request", new_callable=AsyncMock
-            ) as mock_request,
-            patch(
-                "app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock
-            ) as mock_sleep,
+            patch.object(client._client, "request", new_callable=AsyncMock) as mock_request,
+            patch("app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
             mock_request.side_effect = [self._http_status_error(400, "bad request")]
 
@@ -787,12 +765,8 @@ class TestCalComClientRetry:
     @pytest.mark.asyncio
     async def test_raises_after_retry_exhausted(self, client):
         with (
-            patch.object(
-                client._client, "request", new_callable=AsyncMock
-            ) as mock_request,
-            patch(
-                "app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock
-            ) as mock_sleep,
+            patch.object(client._client, "request", new_callable=AsyncMock) as mock_request,
+            patch("app.services.calcom_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
             mock_request.side_effect = [
                 self._http_status_error(503, "unavailable") for _ in range(4)

--- a/tests/test_calcom_client.py
+++ b/tests/test_calcom_client.py
@@ -591,6 +591,69 @@ class TestCalComClientRetry:
         assert exc_info.value.code == "email_domain_cannot_receive_mail"
 
     @pytest.mark.asyncio
+    async def test_error_log_does_not_expose_response_profile_values(
+        self, client, caplog
+    ):
+        private_values = "Alice Europe/Moscow alice@example.com"
+        response = httpx.Response(
+            400,
+            request=httpx.Request("POST", "https://api.cal.com/v2/bookings"),
+            json={"message": private_values},
+        )
+        caplog.set_level("ERROR")
+
+        with patch.object(
+            client._client,
+            "request",
+            new_callable=AsyncMock,
+            return_value=response,
+        ):
+            with pytest.raises(CalComAPIError):
+                await client._request(
+                    "POST",
+                    "/bookings",
+                    api_version="2026-02-25",
+                    json={},
+                )
+
+        assert "Cal.com API error" in caplog.text
+        assert private_values not in caplog.text
+        assert "alice@example.com" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_availability_cache_log_omits_timezone(self, client, caplog):
+        timezone_id = "Europe/Moscow"
+        response = {
+            "status": "success",
+            "data": {"slots": {}},
+        }
+        caplog.set_level("DEBUG")
+
+        with patch.object(
+            client,
+            "_request",
+            new_callable=AsyncMock,
+            return_value=response,
+        ):
+            await client.get_availability(
+                event_type_id=42,
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 2),
+                timezone=timezone_id,
+                duration_minutes=30,
+            )
+            await client.get_availability(
+                event_type_id=42,
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 1, 2),
+                timezone=timezone_id,
+                duration_minutes=30,
+            )
+
+        assert "Cache hit for availability" in caplog.text
+        assert timezone_id not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_retries_retryable_status_then_succeeds(self, client):
         with (
             patch.object(

--- a/tests/test_conversation_isolation.py
+++ b/tests/test_conversation_isolation.py
@@ -1,20 +1,38 @@
-"""Application-level regressions for overlapping user conversations."""
+"""Application-level regressions for switching between user conversations."""
 
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from telegram import Chat, Message, MessageEntity, Update, User
-from telegram.ext import MessageHandler, filters
+from telegram import (
+    CallbackQuery,
+    Chat,
+    Message,
+    MessageEntity,
+    Update,
+    User,
+)
+from telegram.ext import Application, MessageHandler, filters
 
-from app.handlers.booking import BookingState, create_booking_conversation_handler
-from app.handlers.privacy import PrivacyState, create_privacy_conversation_handler
+from app.database import Database
+from app.database.migrations import initialize_schema
+from app.handlers.booking import BookingState
+from app.handlers.privacy import (
+    PrivacyState,
+    invalidate_pending_privacy_input,
+)
 from app.services.user_preferences import UserPreferenceService
 
 
+def _user() -> User:
+    return User(id=12345, first_name="Test", is_bot=False)
+
+
+def _chat() -> Chat:
+    return Chat(id=12345, type=Chat.PRIVATE)
+
+
 def _message_update(application, update_id: int, text: str) -> Update:
-    user = User(id=12345, first_name="Test", is_bot=False)
-    chat = Chat(id=12345, type=Chat.PRIVATE)
     entities = None
     if text.startswith("/"):
         entities = [
@@ -27,8 +45,8 @@ def _message_update(application, update_id: int, text: str) -> Update:
     message = Message(
         message_id=update_id,
         date=datetime.now(timezone.utc),
-        chat=chat,
-        from_user=user,
+        chat=_chat(),
+        from_user=_user(),
         text=text,
         entities=entities,
     )
@@ -36,16 +54,30 @@ def _message_update(application, update_id: int, text: str) -> Update:
     return Update(update_id=update_id, message=message)
 
 
-@pytest.mark.asyncio
-async def test_booking_name_wins_over_abandoned_privacy_name_input(
-    monkeypatch,
-    temp_db_path,
-):
-    from telegram.ext import Application
+def _callback_update(application, update_id: int, data: str) -> Update:
+    message = Message(
+        message_id=update_id,
+        date=datetime.now(timezone.utc),
+        chat=_chat(),
+        from_user=application.bot._bot_user,
+        text="privacy",
+    )
+    message.set_bot(application.bot)
+    query = CallbackQuery(
+        id=f"callback-{update_id}",
+        from_user=_user(),
+        chat_instance="test-chat",
+        message=message,
+        data=data,
+    )
+    query.set_bot(application.bot)
+    return Update(update_id=update_id, callback_query=query)
 
-    from app.database import Database
-    from app.database.migrations import initialize_schema
-    from app.handlers.privacy import invalidate_pending_privacy_input
+
+def _application(monkeypatch, temp_db_path):
+    from app.handlers.user_conversation import (
+        create_user_conversation_handler,
+    )
 
     application = Application.builder().token("123456:test-token").build()
     application._initialized = True
@@ -57,6 +89,16 @@ async def test_booking_name_wins_over_abandoned_privacy_name_input(
         username="telecalbot_test_bot",
     )
     monkeypatch.setattr(application.bot.__class__, "send_message", AsyncMock())
+    monkeypatch.setattr(
+        application.bot.__class__,
+        "answer_callback_query",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        application.bot.__class__,
+        "edit_message_text",
+        AsyncMock(),
+    )
 
     db = Database(temp_db_path)
     initialize_schema(db)
@@ -73,22 +115,73 @@ async def test_booking_name_wins_over_abandoned_privacy_name_input(
         }
     )
 
-    booking = create_booking_conversation_handler()
-    privacy = create_privacy_conversation_handler()
+    conversation = create_user_conversation_handler()
     application.add_handler(
-        MessageHandler(filters.COMMAND, invalidate_pending_privacy_input),
+        MessageHandler(
+            filters.COMMAND,
+            invalidate_pending_privacy_input,
+        ),
         group=-1,
     )
-    application.add_handler(booking)
-    application.add_handler(privacy)
+    application.add_handler(conversation)
+    return application, conversation, profile_service
 
-    conversation_key = (12345, 12345)
-    privacy._conversations[conversation_key] = PrivacyState.ENTERING_NAME
-    application.user_data[12345]["privacy_pending_input"] = "name"
 
-    await application.process_update(_message_update(application, 1, "/book"))
-    booking._conversations[conversation_key] = BookingState.ENTERING_NAME
-    await application.process_update(_message_update(application, 2, "Booking Name"))
+@pytest.mark.asyncio
+async def test_book_replaces_abandoned_privacy_name_input(
+    monkeypatch,
+    temp_db_path,
+):
+    application, conversation, profile_service = _application(
+        monkeypatch,
+        temp_db_path,
+    )
+    key = (12345, 12345)
+
+    await application.process_update(
+        _message_update(application, 1, "/privacy")
+    )
+    await application.process_update(
+        _callback_update(application, 2, "privacy:edit_name")
+    )
+    assert conversation._conversations[key] == PrivacyState.ENTERING_NAME
+
+    await application.process_update(_message_update(application, 3, "/book"))
+    conversation._conversations[key] = BookingState.ENTERING_NAME
+    await application.process_update(
+        _message_update(application, 4, "Booking Name")
+    )
 
     assert application.user_data[12345]["name"] == "Booking Name"
     assert profile_service.get_profile(12345) is None
+
+
+@pytest.mark.asyncio
+async def test_privacy_replaces_booking_and_receives_its_name_input(
+    monkeypatch,
+    temp_db_path,
+):
+    application, conversation, profile_service = _application(
+        monkeypatch,
+        temp_db_path,
+    )
+    key = (12345, 12345)
+
+    await application.process_update(_message_update(application, 1, "/book"))
+    conversation._conversations[key] = BookingState.ENTERING_NAME
+    application.user_data[12345]["selected_date"] = "2026-01-06"
+
+    await application.process_update(
+        _message_update(application, 2, "/privacy")
+    )
+    await application.process_update(
+        _callback_update(application, 3, "privacy:edit_name")
+    )
+    await application.process_update(
+        _message_update(application, 4, "Privacy Name")
+    )
+
+    profile = profile_service.get_profile(12345)
+    assert profile is not None
+    assert profile.preferred_name == "Privacy Name"
+    assert "selected_date" not in application.user_data[12345]

--- a/tests/test_conversation_isolation.py
+++ b/tests/test_conversation_isolation.py
@@ -1,0 +1,92 @@
+"""Application-level regressions for overlapping user conversations."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram import Chat, Message, MessageEntity, Update, User
+from telegram.ext import MessageHandler, filters
+
+from app.handlers.booking import BookingState, create_booking_conversation_handler
+from app.handlers.privacy import PrivacyState, create_privacy_conversation_handler
+from app.services.user_preferences import UserPreferenceService
+
+
+def _message_update(application, update_id: int, text: str) -> Update:
+    user = User(id=12345, first_name="Test", is_bot=False)
+    chat = Chat(id=12345, type=Chat.PRIVATE)
+    entities = None
+    if text.startswith("/"):
+        entities = [
+            MessageEntity(
+                type=MessageEntity.BOT_COMMAND,
+                offset=0,
+                length=len(text.split()[0]),
+            )
+        ]
+    message = Message(
+        message_id=update_id,
+        date=datetime.now(timezone.utc),
+        chat=chat,
+        from_user=user,
+        text=text,
+        entities=entities,
+    )
+    message.set_bot(application.bot)
+    return Update(update_id=update_id, message=message)
+
+
+@pytest.mark.asyncio
+async def test_booking_name_wins_over_abandoned_privacy_name_input(
+    monkeypatch,
+    temp_db_path,
+):
+    from telegram.ext import Application
+
+    from app.database import Database
+    from app.database.migrations import initialize_schema
+    from app.handlers.privacy import invalidate_pending_privacy_input
+
+    application = Application.builder().token("123456:test-token").build()
+    application._initialized = True
+    application.bot._initialized = True
+    application.bot._bot_user = User(
+        id=999,
+        first_name="Telecalbot",
+        is_bot=True,
+        username="telecalbot_test_bot",
+    )
+    monkeypatch.setattr(application.bot, "send_message", AsyncMock())
+
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    profile_service = UserPreferenceService(db)
+    whitelist_service = MagicMock()
+    whitelist_service.is_whitelisted.return_value = True
+    application.bot_data.update(
+        {
+            "user_preference_service": profile_service,
+            "whitelist_service": whitelist_service,
+            "duration_limit_service": MagicMock(),
+        }
+    )
+
+    booking = create_booking_conversation_handler()
+    privacy = create_privacy_conversation_handler()
+    application.add_handler(
+        MessageHandler(filters.COMMAND, invalidate_pending_privacy_input),
+        group=-1,
+    )
+    application.add_handler(booking)
+    application.add_handler(privacy)
+
+    conversation_key = (12345, 12345)
+    privacy._conversations[conversation_key] = PrivacyState.ENTERING_NAME
+    application.user_data[12345]["privacy_pending_input"] = "name"
+
+    await application.process_update(_message_update(application, 1, "/book"))
+    booking._conversations[conversation_key] = BookingState.ENTERING_NAME
+    await application.process_update(_message_update(application, 2, "Booking Name"))
+
+    assert application.user_data[12345]["name"] == "Booking Name"
+    assert profile_service.get_profile(12345) is None

--- a/tests/test_conversation_isolation.py
+++ b/tests/test_conversation_isolation.py
@@ -56,18 +56,20 @@ async def test_booking_name_wins_over_abandoned_privacy_name_input(
         is_bot=True,
         username="telecalbot_test_bot",
     )
-    monkeypatch.setattr(application.bot, "send_message", AsyncMock())
+    monkeypatch.setattr(application.bot.__class__, "send_message", AsyncMock())
 
     db = Database(temp_db_path)
     initialize_schema(db)
     profile_service = UserPreferenceService(db)
     whitelist_service = MagicMock()
     whitelist_service.is_whitelisted.return_value = True
+    duration_limit_service = MagicMock()
+    duration_limit_service.get_limit.return_value = None
     application.bot_data.update(
         {
             "user_preference_service": profile_service,
             "whitelist_service": whitelist_service,
-            "duration_limit_service": MagicMock(),
+            "duration_limit_service": duration_limit_service,
         }
     )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -248,6 +248,54 @@ def test_migration_resets_legacy_automatically_saved_timezones(temp_db_path):
     }
 
 
+def test_profile_migration_preserves_unknown_schema_and_fails_closed(
+    temp_db_path,
+    caplog,
+):
+    db = Database(temp_db_path)
+    db.execute_write(
+        """
+        CREATE TABLE user_preferences (
+            telegram_id INTEGER PRIMARY KEY,
+            preferred_name TEXT,
+            timezone TEXT,
+            email_mode TEXT NOT NULL,
+            email TEXT,
+            updated_at TEXT NOT NULL,
+            future_consent_field TEXT
+        )
+        """
+    )
+    db.execute_write(
+        """
+        INSERT INTO user_preferences (
+            telegram_id, preferred_name, timezone, email_mode, email, updated_at,
+            future_consent_field
+        ) VALUES (?, ?, ?, 'saved', ?, ?, ?)
+        """,
+        (
+            123,
+            "Alice",
+            "Europe/Moscow",
+            "alice@example.com",
+            "2026-07-23T00:00:00+00:00",
+            "keep-me",
+        ),
+    )
+    caplog.set_level("ERROR")
+
+    with pytest.raises(RuntimeError, match="Unexpected user_preferences schema"):
+        run_migrations(db)
+
+    row = db.execute_one(
+        "SELECT * FROM user_preferences WHERE telegram_id = ?",
+        (123,),
+    )
+    assert row is not None
+    assert row["future_consent_field"] == "keep-me"
+    assert "Unexpected user_preferences schema" in caplog.text
+
+
 def test_user_profile_migration_is_idempotent_and_preserves_explicit_profile(
     temp_db_path,
 ):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,5 +1,9 @@
 """Tests for database functionality."""
 
+import sqlite3
+
+import pytest
+
 from app.database import Database
 from app.database.migrations import initialize_schema, run_migrations
 
@@ -31,6 +35,74 @@ def test_schema_initialization(temp_db_path):
         row["name"] for row in db.execute("PRAGMA table_info(bookings)")
     }
     assert "internal_ref" in booking_columns
+
+
+def test_user_profile_schema_has_nullable_consent_fields(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+
+    columns = {
+        row["name"]: row for row in db.execute("PRAGMA table_info(user_preferences)")
+    }
+
+    assert set(columns) == {
+        "telegram_id",
+        "preferred_name",
+        "timezone",
+        "email_mode",
+        "email",
+        "updated_at",
+    }
+    assert columns["preferred_name"]["notnull"] == 0
+    assert columns["timezone"]["notnull"] == 0
+    assert columns["email"]["notnull"] == 0
+    assert columns["email_mode"]["dflt_value"] == "'ask'"
+
+
+@pytest.mark.parametrize("email_mode", ["unknown", "", "SAVED"])
+def test_user_profile_schema_rejects_invalid_email_modes(temp_db_path, email_mode):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute_write(
+            """
+            INSERT INTO user_preferences (telegram_id, email_mode, updated_at)
+            VALUES (?, ?, ?)
+            """,
+            (123, email_mode, "2026-07-21T00:00:00+00:00"),
+        )
+
+
+def test_user_profile_schema_requires_email_only_for_saved_mode(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute_write(
+            """
+            INSERT INTO user_preferences (telegram_id, email_mode, email, updated_at)
+            VALUES (?, 'saved', NULL, ?)
+            """,
+            (123, "2026-07-21T00:00:00+00:00"),
+        )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute_write(
+            """
+            INSERT INTO user_preferences (telegram_id, email_mode, email, updated_at)
+            VALUES (?, 'private', ?, ?)
+            """,
+            (456, "private-value@example.com", "2026-07-21T00:00:00+00:00"),
+        )
+
+    db.execute_write(
+        """
+        INSERT INTO user_preferences (telegram_id, email_mode, email, updated_at)
+        VALUES (?, 'saved', ?, ?)
+        """,
+        (789, "saved@example.com", "2026-07-21T00:00:00+00:00"),
+    )
 
 
 def test_whitelist_insert_and_query(temp_db_path):
@@ -137,3 +209,73 @@ def test_migrates_bookings_start_end_columns(temp_db_path):
     assert row["start_at"] == "2026-01-01T10:00:00Z"
     assert row["end_at"] == "2026-01-01T11:00:00Z"
     assert "internal_ref" in columns
+
+
+def test_migration_resets_legacy_automatically_saved_timezones(temp_db_path):
+    db = Database(temp_db_path)
+    db.execute_write(
+        """
+        CREATE TABLE user_preferences (
+            telegram_id INTEGER PRIMARY KEY,
+            timezone TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    db.execute_write(
+        """
+        INSERT INTO user_preferences (telegram_id, timezone, updated_at)
+        VALUES (?, ?, ?)
+        """,
+        (123, "Europe/Moscow", "2026-07-20T00:00:00+00:00"),
+    )
+
+    run_migrations(db)
+
+    assert db.execute_one(
+        "SELECT * FROM user_preferences WHERE telegram_id = ?", (123,)
+    ) is None
+    columns = {
+        row["name"] for row in db.execute("PRAGMA table_info(user_preferences)")
+    }
+    assert columns == {
+        "telegram_id",
+        "preferred_name",
+        "timezone",
+        "email_mode",
+        "email",
+        "updated_at",
+    }
+
+
+def test_user_profile_migration_is_idempotent_and_preserves_explicit_profile(
+    temp_db_path,
+):
+    db = Database(temp_db_path)
+    run_migrations(db)
+    db.execute_write(
+        """
+        INSERT INTO user_preferences (
+            telegram_id, preferred_name, timezone, email_mode, email, updated_at
+        ) VALUES (?, ?, ?, 'saved', ?, ?)
+        """,
+        (
+            123,
+            "Alice",
+            "Europe/Moscow",
+            "alice@example.com",
+            "2026-07-21T00:00:00+00:00",
+        ),
+    )
+
+    run_migrations(db)
+    run_migrations(db)
+
+    row = db.execute_one(
+        "SELECT * FROM user_preferences WHERE telegram_id = ?", (123,)
+    )
+    assert row is not None
+    assert row["preferred_name"] == "Alice"
+    assert row["timezone"] == "Europe/Moscow"
+    assert row["email_mode"] == "saved"
+    assert row["email"] == "alice@example.com"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,27 @@ class TestErrorHandler:
         assert private_values not in caplog.text
         assert "alice@example.com" not in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_unhandled_exception_log_includes_safe_traceback_frames(self, caplog):
+        caplog.set_level("ERROR")
+        private_values = "Alice Europe/Moscow alice@example.com"
+        context = MagicMock()
+
+        def raise_private_error():
+            raise RuntimeError(private_values)
+
+        try:
+            raise_private_error()
+        except RuntimeError as error:
+            context.error = error
+
+        await error_handler({"message": private_values}, context)
+
+        assert "raise_private_error" in caplog.text
+        assert "test_main.py" in caplog.text
+        assert private_values not in caplog.text
+        assert "alice@example.com" not in caplog.text
+
 
 class TestMain:
     """Tests for main application wiring."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,6 +34,19 @@ class TestErrorHandler:
 
         assert "Unhandled exception while processing update" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_unhandled_exception_log_omits_private_values(self, caplog):
+        caplog.set_level("ERROR")
+        private_values = "Alice Europe/Moscow alice@example.com"
+        context = MagicMock()
+        context.error = RuntimeError(private_values)
+
+        await error_handler({"message": private_values}, context)
+
+        assert "Unhandled exception while processing update" in caplog.text
+        assert private_values not in caplog.text
+        assert "alice@example.com" not in caplog.text
+
 
 class TestMain:
     """Tests for main application wiring."""

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telegram.error import BadRequest
 from telegram.ext import CommandHandler, ConversationHandler
 
 from app import handlers
@@ -312,3 +313,56 @@ async def test_privacy_delete_failure_does_not_claim_profile_was_deleted(caplog)
     assert "профиль удален" not in response.lower()
     assert private_values not in caplog.text
     assert "alice@example.com" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_privacy_ignores_unchanged_message_edit(profile_service):
+    profile_service.save_private_email_mode(12345)
+    context = _context(profile_service, whitelisted=True)
+    update = _callback_update("privacy:private_email")
+    update.callback_query.edit_message_text.side_effect = BadRequest(
+        "Message is not modified: specified new message content and reply markup "
+        "are exactly the same as a current content and reply markup of the message"
+    )
+
+    result = await handlers.privacy_callback(update, context)
+
+    assert result == handlers.PrivacyState.VIEWING
+
+
+@pytest.mark.asyncio
+async def test_privacy_does_not_hide_other_message_edit_errors(profile_service):
+    profile_service.save_private_email_mode(12345)
+    context = _context(profile_service, whitelisted=True)
+    update = _callback_update("privacy:private_email")
+    update.callback_query.edit_message_text.side_effect = BadRequest("Chat not found")
+
+    with pytest.raises(BadRequest, match="Chat not found"):
+        await handlers.privacy_callback(update, context)
+
+
+@pytest.mark.asyncio
+async def test_privacy_callback_handles_missing_profile_service():
+    context = _context(MagicMock())
+    context.bot_data.pop("user_preference_service")
+    update = _callback_update("privacy:back")
+
+    result = await handlers.privacy_callback(update, context)
+
+    assert result == handlers.PrivacyState.VIEWING
+    response = update.callback_query.edit_message_text.call_args.args[0]
+    assert "не удалось загрузить" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_privacy_rejects_email_longer_than_254_characters(profile_service):
+    context = _context(profile_service, whitelisted=True)
+    context.user_data["privacy_pending_input"] = "email"
+    email = f"{'a' * (255 - len('@example.com'))}@example.com"
+    update = _message_update(email)
+
+    result = await handlers.privacy_enter_email(update, context)
+
+    assert result == handlers.PrivacyState.ENTERING_EMAIL
+    assert profile_service.get_profile(12345) is None
+    assert "254" in update.message.reply_text.call_args.args[0]

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,197 @@
+"""Tests for the reversible /privacy booking-profile flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app import handlers
+from app.database import Database
+from app.database.migrations import initialize_schema
+from app.services.user_preferences import UserPreferenceService
+
+
+@pytest.fixture
+def profile_service(temp_db_path):
+    db = Database(temp_db_path)
+    initialize_schema(db)
+    return UserPreferenceService(db)
+
+
+def _context(profile_service, *, whitelisted=False):
+    context = MagicMock()
+    context.user_data = {}
+    context.bot_data = {
+        "user_preference_service": profile_service,
+        "whitelist_service": MagicMock(),
+    }
+    context.bot_data["whitelist_service"].is_whitelisted.return_value = whitelisted
+    return context
+
+
+def _message_update(text="/privacy", user_id=12345):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message = AsyncMock()
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    update.callback_query = None
+    return update
+
+
+def _callback_update(data, user_id=12345):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message = None
+    update.callback_query = AsyncMock()
+    update.callback_query.data = data
+    update.callback_query.from_user.id = user_id
+    update.callback_query.answer = AsyncMock()
+    update.callback_query.edit_message_text = AsyncMock()
+    update.callback_query.message = AsyncMock()
+    return update
+
+
+@pytest.mark.asyncio
+async def test_privacy_displays_masked_profile_without_whitelist_access(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_email(12345, "alice@example.com")
+    context = _context(profile_service, whitelisted=False)
+    update = _message_update()
+
+    await handlers.privacy_command(update, context)
+
+    response = update.message.reply_text.call_args.args[0]
+    assert "Alice" in response
+    assert "Europe/Moscow" in response
+    assert "a***@example.com" in response
+    assert "alice@example.com" not in response
+    assert "не отменяет" in response.lower()
+    assert "telegram" in response.lower()
+    context.bot_data["whitelist_service"].is_whitelisted.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [("private", "без личного email"), ("ask", "спрашивать каждый раз")],
+)
+async def test_privacy_displays_private_and_ask_email_modes(
+    profile_service, mode, expected
+):
+    profile_service.save_preferred_name(12345, "Alice")
+    if mode == "private":
+        profile_service.save_private_email_mode(12345)
+    context = _context(profile_service)
+    update = _message_update()
+
+    await handlers.privacy_command(update, context)
+
+    assert expected in update.message.reply_text.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_privacy_callbacks_are_opaque(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_email(12345, "alice@example.com")
+    context = _context(profile_service)
+    update = _message_update()
+
+    await handlers.privacy_command(update, context)
+
+    keyboard = update.message.reply_text.call_args.kwargs["reply_markup"]
+    callbacks = [
+        button.callback_data for row in keyboard.inline_keyboard for button in row
+    ]
+    serialized = " ".join(callbacks)
+    assert "Alice" not in serialized
+    assert "Europe/Moscow" not in serialized
+    assert "alice@example.com" not in serialized
+    assert set(callbacks) >= {
+        "privacy:edit_name",
+        "privacy:forget_name",
+        "privacy:edit_timezone",
+        "privacy:forget_timezone",
+        "privacy:edit_email",
+        "privacy:private_email",
+        "privacy:ask_email",
+        "privacy:delete_confirm",
+    }
+
+
+@pytest.mark.asyncio
+async def test_privacy_forgets_one_field_without_removing_others(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_private_email_mode(12345)
+    context = _context(profile_service)
+    update = _callback_update("privacy:forget_name")
+
+    await handlers.privacy_callback(update, context)
+
+    profile = profile_service.get_profile(12345)
+    assert profile is not None
+    assert profile.preferred_name is None
+    assert profile.timezone == "Europe/Moscow"
+    assert profile.email_mode == "private"
+
+
+@pytest.mark.asyncio
+async def test_privacy_deletes_complete_profile_for_non_whitelisted_user(
+    profile_service,
+):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_email(12345, "alice@example.com")
+    context = _context(profile_service, whitelisted=False)
+    update = _callback_update("privacy:delete_profile")
+
+    result = await handlers.privacy_callback(update, context)
+
+    assert result == handlers.PrivacyState.END
+    assert profile_service.get_profile(12345) is None
+    response = update.callback_query.edit_message_text.call_args.args[0]
+    assert "удален" in response.lower()
+    assert "не отмен" in response.lower()
+    context.bot_data["whitelist_service"].is_whitelisted.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_privacy_changes_name_timezone_and_email(profile_service):
+    profile_service.save_private_email_mode(12345)
+    context = _context(profile_service)
+
+    name_update = _message_update("New Name")
+    assert (
+        await handlers.privacy_enter_name(name_update, context)
+        == handlers.PrivacyState.END
+    )
+
+    timezone_update = _callback_update("privacy_tz:3")
+    assert (
+        await handlers.privacy_select_timezone(timezone_update, context)
+        == handlers.PrivacyState.END
+    )
+
+    email_update = _message_update("new@example.com")
+    assert (
+        await handlers.privacy_enter_email(email_update, context)
+        == handlers.PrivacyState.END
+    )
+
+    profile = profile_service.get_profile(12345)
+    assert profile is not None
+    assert profile.preferred_name == "New Name"
+    assert profile.timezone == "Asia/Yekaterinburg"
+    assert profile.email_mode == "saved"
+    assert profile.email == "new@example.com"
+
+
+def test_privacy_conversation_registers_command_and_edit_states():
+    conversation = handlers.create_privacy_conversation_handler()
+
+    assert conversation.entry_points[0].commands == frozenset({"privacy"})
+    assert handlers.PrivacyState.ENTERING_NAME in conversation.states
+    assert handlers.PrivacyState.SELECTING_TIMEZONE in conversation.states
+    assert handlers.PrivacyState.ENTERING_EMAIL in conversation.states

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,10 +1,13 @@
 """Tests for the reversible /privacy booking-profile flow."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telegram.ext import CommandHandler, ConversationHandler
 
 from app import handlers
+from app.config import settings
 from app.database import Database
 from app.database.migrations import initialize_schema
 from app.services.user_preferences import UserPreferenceService
@@ -156,7 +159,7 @@ async def test_privacy_deletes_complete_profile_for_non_whitelisted_user(
 @pytest.mark.asyncio
 async def test_privacy_changes_name_timezone_and_email(profile_service):
     profile_service.save_private_email_mode(12345)
-    context = _context(profile_service)
+    context = _context(profile_service, whitelisted=True)
 
     name_update = _message_update("New Name")
     assert await handlers.privacy_enter_name(name_update, context) == handlers.PrivacyState.VIEWING
@@ -187,6 +190,87 @@ def test_privacy_conversation_registers_command_and_edit_states():
     assert handlers.PrivacyState.ENTERING_NAME in conversation.states
     assert handlers.PrivacyState.SELECTING_TIMEZONE in conversation.states
     assert handlers.PrivacyState.ENTERING_EMAIL in conversation.states
+    assert ConversationHandler.TIMEOUT in conversation.states
+    assert conversation.conversation_timeout == timedelta(
+        seconds=settings.booking_conversation_timeout_seconds
+    )
+    assert any(
+        isinstance(handler, CommandHandler) and handler.commands == frozenset({"cancel"})
+        for handler in conversation.fallbacks
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action",
+    ["privacy:edit_name", "privacy:edit_timezone", "privacy:edit_email", "privacy:private_email"],
+)
+async def test_privacy_blocks_profile_value_writes_without_whitelist_access(
+    profile_service,
+    action,
+):
+    context = _context(profile_service, whitelisted=False)
+    update = _callback_update(action)
+
+    result = await handlers.privacy_callback(update, context)
+
+    assert result == handlers.PrivacyState.VIEWING
+    assert profile_service.get_profile(12345) is None
+    response = update.callback_query.edit_message_text.call_args.args[0]
+    assert "одобрен" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_privacy_rechecks_whitelist_before_saving_text_input(profile_service):
+    context = _context(profile_service, whitelisted=True)
+    context.user_data["privacy_pending_input"] = "name"
+    context.bot_data["whitelist_service"].is_whitelisted.return_value = False
+    update = _message_update("Booking Name")
+
+    result = await handlers.privacy_enter_name(update, context)
+
+    assert result == handlers.PrivacyState.END
+    assert profile_service.get_profile(12345) is None
+    assert "одобрен" in update.message.reply_text.call_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_privacy_cancel_clears_pending_input(profile_service):
+    context = _context(profile_service, whitelisted=True)
+    context.user_data["privacy_pending_input"] = "email"
+    update = _message_update("/cancel")
+
+    result = await handlers.privacy_cancel(update, context)
+
+    assert result == handlers.PrivacyState.END
+    assert "privacy_pending_input" not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_privacy_timeout_clears_pending_input(profile_service):
+    context = _context(profile_service, whitelisted=True)
+    context.user_data["privacy_pending_input"] = "timezone"
+    update = _message_update()
+
+    result = await handlers.privacy_timeout(update, context)
+
+    assert result == handlers.PrivacyState.END
+    assert "privacy_pending_input" not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_invalidated_privacy_input_cannot_save_booking_name(profile_service):
+    context = _context(profile_service, whitelisted=True)
+    context.user_data["privacy_pending_input"] = "name"
+    command_update = _message_update("/book")
+
+    await handlers.invalidate_pending_privacy_input(command_update, context)
+
+    name_update = _message_update("Booking Name")
+    result = await handlers.privacy_enter_name(name_update, context)
+
+    assert result == handlers.PrivacyState.END
+    assert profile_service.get_profile(12345) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -76,9 +76,7 @@ async def test_privacy_displays_masked_profile_without_whitelist_access(profile_
     ("mode", "expected"),
     [("private", "без личного email"), ("ask", "спрашивать каждый раз")],
 )
-async def test_privacy_displays_private_and_ask_email_modes(
-    profile_service, mode, expected
-):
+async def test_privacy_displays_private_and_ask_email_modes(profile_service, mode, expected):
     profile_service.save_preferred_name(12345, "Alice")
     if mode == "private":
         profile_service.save_private_email_mode(12345)
@@ -101,9 +99,7 @@ async def test_privacy_callbacks_are_opaque(profile_service):
     await handlers.privacy_command(update, context)
 
     keyboard = update.message.reply_text.call_args.kwargs["reply_markup"]
-    callbacks = [
-        button.callback_data for row in keyboard.inline_keyboard for button in row
-    ]
+    callbacks = [button.callback_data for row in keyboard.inline_keyboard for button in row]
     serialized = " ".join(callbacks)
     assert "Alice" not in serialized
     assert "Europe/Moscow" not in serialized
@@ -163,21 +159,17 @@ async def test_privacy_changes_name_timezone_and_email(profile_service):
     context = _context(profile_service)
 
     name_update = _message_update("New Name")
-    assert (
-        await handlers.privacy_enter_name(name_update, context)
-        == handlers.PrivacyState.END
-    )
+    assert await handlers.privacy_enter_name(name_update, context) == handlers.PrivacyState.VIEWING
 
     timezone_update = _callback_update("privacy_tz:3")
     assert (
         await handlers.privacy_select_timezone(timezone_update, context)
-        == handlers.PrivacyState.END
+        == handlers.PrivacyState.VIEWING
     )
 
     email_update = _message_update("new@example.com")
     assert (
-        await handlers.privacy_enter_email(email_update, context)
-        == handlers.PrivacyState.END
+        await handlers.privacy_enter_email(email_update, context) == handlers.PrivacyState.VIEWING
     )
 
     profile = profile_service.get_profile(12345)

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -37,6 +37,7 @@ def _message_update(text="/privacy", user_id=12345):
     update.message = AsyncMock()
     update.message.text = text
     update.message.reply_text = AsyncMock()
+    update.effective_message = update.message
     update.callback_query = None
     return update
 
@@ -162,15 +163,18 @@ async def test_privacy_changes_name_timezone_and_email(profile_service):
     context = _context(profile_service, whitelisted=True)
 
     name_update = _message_update("New Name")
+    context.user_data["privacy_pending_input"] = "name"
     assert await handlers.privacy_enter_name(name_update, context) == handlers.PrivacyState.VIEWING
 
     timezone_update = _callback_update("privacy_tz:3")
+    context.user_data["privacy_pending_input"] = "timezone"
     assert (
         await handlers.privacy_select_timezone(timezone_update, context)
         == handlers.PrivacyState.VIEWING
     )
 
     email_update = _message_update("new@example.com")
+    context.user_data["privacy_pending_input"] = "email"
     assert (
         await handlers.privacy_enter_email(email_update, context) == handlers.PrivacyState.VIEWING
     )

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -187,3 +187,40 @@ def test_privacy_conversation_registers_command_and_edit_states():
     assert handlers.PrivacyState.ENTERING_NAME in conversation.states
     assert handlers.PrivacyState.SELECTING_TIMEZONE in conversation.states
     assert handlers.PrivacyState.ENTERING_EMAIL in conversation.states
+
+
+@pytest.mark.asyncio
+async def test_privacy_load_failure_is_not_presented_as_an_empty_profile(caplog):
+    private_values = "Alice Europe/Moscow alice@example.com"
+    profile_service = MagicMock()
+    profile_service.get_profile.side_effect = RuntimeError(private_values)
+    context = _context(profile_service)
+    update = _message_update()
+    caplog.set_level("ERROR")
+
+    await handlers.privacy_command(update, context)
+
+    response = update.message.reply_text.call_args.args[0]
+    assert "не удалось загрузить" in response.lower()
+    assert "Имя: не сохранено" not in response
+    assert private_values not in caplog.text
+    assert "alice@example.com" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_privacy_delete_failure_does_not_claim_profile_was_deleted(caplog):
+    private_values = "Alice Europe/Moscow alice@example.com"
+    profile_service = MagicMock()
+    profile_service.clear_profile.side_effect = RuntimeError(private_values)
+    context = _context(profile_service, whitelisted=False)
+    update = _callback_update("privacy:delete_profile")
+    caplog.set_level("ERROR")
+
+    result = await handlers.privacy_callback(update, context)
+
+    assert result == handlers.PrivacyState.VIEWING
+    response = update.callback_query.edit_message_text.call_args.args[0]
+    assert "не удалось удалить" in response.lower()
+    assert "профиль удален" not in response.lower()
+    assert private_values not in caplog.text
+    assert "alice@example.com" not in caplog.text

--- a/tests/test_user_preferences.py
+++ b/tests/test_user_preferences.py
@@ -1,40 +1,102 @@
-"""Tests for persisted user profile preferences."""
+"""Tests for explicitly consented booking profile preferences."""
+
+import pytest
 
 from app.database import Database
 from app.database.migrations import initialize_schema
 from app.services.user_preferences import UserPreferenceService
 
 
-def test_returns_none_when_user_has_no_preferences(temp_db_path):
+@pytest.fixture
+def profile_service(temp_db_path):
     db = Database(temp_db_path)
     initialize_schema(db)
-    service = UserPreferenceService(db)
-
-    assert service.get_timezone(12345) is None
+    return UserPreferenceService(db)
 
 
-def test_saves_and_loads_timezone_preference(temp_db_path):
-    db = Database(temp_db_path)
-    initialize_schema(db)
-    service = UserPreferenceService(db)
-
-    service.set_timezone(12345, "Europe/Moscow")
-
-    preference = service.get_timezone(12345)
-    assert preference is not None
-    assert preference.telegram_id == 12345
-    assert preference.timezone == "Europe/Moscow"
-    assert preference.updated_at.tzinfo is not None
+def test_returns_none_when_user_has_no_profile(profile_service):
+    assert profile_service.get_profile(12345) is None
 
 
-def test_updates_existing_timezone_preference(temp_db_path):
-    db = Database(temp_db_path)
-    initialize_schema(db)
-    service = UserPreferenceService(db)
+def test_saves_and_loads_granular_profile_fields(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_email(12345, "alice@example.com")
 
-    service.set_timezone(12345, "Europe/Moscow")
-    service.set_timezone(12345, "Asia/Yekaterinburg")
+    profile = profile_service.get_profile(12345)
 
-    preference = service.get_timezone(12345)
-    assert preference is not None
-    assert preference.timezone == "Asia/Yekaterinburg"
+    assert profile is not None
+    assert profile.telegram_id == 12345
+    assert profile.preferred_name == "Alice"
+    assert profile.timezone == "Europe/Moscow"
+    assert profile.email_mode == "saved"
+    assert profile.email == "alice@example.com"
+    assert profile.updated_at.tzinfo is not None
+
+
+def test_profile_survives_service_restart(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Asia/Yekaterinburg")
+
+    restarted_service = UserPreferenceService(profile_service.db)
+    profile = restarted_service.get_profile(12345)
+
+    assert profile is not None
+    assert profile.preferred_name == "Alice"
+    assert profile.timezone == "Asia/Yekaterinburg"
+
+
+def test_rejects_unsupported_timezone_without_creating_profile(profile_service):
+    with pytest.raises(ValueError, match="Unsupported timezone"):
+        profile_service.save_timezone(12345, "Europe/Removed")
+
+    assert profile_service.get_profile(12345) is None
+
+
+def test_private_email_mode_discards_personal_email(profile_service):
+    profile_service.save_email(12345, "alice@example.com")
+
+    profile_service.save_private_email_mode(12345)
+
+    profile = profile_service.get_profile(12345)
+    assert profile is not None
+    assert profile.email_mode == "private"
+    assert profile.email is None
+
+
+def test_clearing_email_returns_to_ask_mode(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_email(12345, "alice@example.com")
+
+    profile_service.clear_email(12345)
+
+    profile = profile_service.get_profile(12345)
+    assert profile is not None
+    assert profile.preferred_name == "Alice"
+    assert profile.email_mode == "ask"
+    assert profile.email is None
+
+
+def test_clear_operations_are_field_specific(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_private_email_mode(12345)
+
+    profile_service.clear_preferred_name(12345)
+    profile_service.clear_timezone(12345)
+
+    profile = profile_service.get_profile(12345)
+    assert profile is not None
+    assert profile.preferred_name is None
+    assert profile.timezone is None
+    assert profile.email_mode == "private"
+
+
+def test_clear_profile_removes_every_remembered_field(profile_service):
+    profile_service.save_preferred_name(12345, "Alice")
+    profile_service.save_timezone(12345, "Europe/Moscow")
+    profile_service.save_email(12345, "alice@example.com")
+
+    profile_service.clear_profile(12345)
+
+    assert profile_service.get_profile(12345) is None


### PR DESCRIPTION
## Summary

- rebuild `user_preferences` as an explicitly consented booking profile with nullable name/timezone fields and constrained `ask | private | saved` email behavior
- reset only the exact legacy auto-saved-timezone schema instead of grandfathering it into consent; fail closed and preserve data for unknown future schema shapes
- reuse only saved fields during `/book`, keep newly entered or changed values transient, and persist only granular selections from the remembering screen
- show complete effective details before booking and provide opaque `Изменить данные` controls
- add `/privacy` display, masked email, field-specific change/forget operations, and complete profile deletion without requiring whitelist access
- keep profile value-add writes whitelist-gated while leaving viewing, forgetting, and deletion available to de-whitelisted users
- remove profile values, email, response bodies, and timezone cache keys from logs and callback payloads
- document the consent and legacy-reset behavior

## Reliability and privacy

- make `/book` and `/privacy` mutually exclusive inside one conversation handler, with privacy timeouts, cancellation, command invalidation, and dispatch-level regression coverage
- cap names and email addresses consistently in handlers and storage; ignore Telegram's harmless “message is not modified” response
- retain useful traceback frames without logging exception messages or incoming updates
- profile storage failures do not block booking or claim that data was saved
- rejected saved email replacements remain one-time unless separately remembered
- changing timezone after slot selection requires selecting a compatible slot again
- successful bookings clear booking-scoped personal data while preserving unrelated user state
- already-saved fields are visibly marked on the remembering screen, which now includes cancellation
- profile deletion explicitly does not cancel active bookings or modify Telegram access records

## Validation

- `uv run pytest tests/ -q` — **339 passed**
- `uv run ruff check .` — passed
- latest CI `validate` job — passed
- latest CI `docker-smoke` fresh production build, application import, and migrations — passed
- current-source Docker application import — `import-ok`
- current-source Docker migrations — `migrations-ok`
- production-image legacy database migration, repeated twice — `legacy-reset-idempotent-ok`
- final automated review through `28556cb` — no actionable findings

## Issue boundaries

- resolves the profile-service naming and timezone write-validation acceptance criteria in #70
- leaves #68 and #69 open; this change does not satisfy their separate adapter-hardening and fifth-step-keyboard acceptance criteria
- leaves #53 open; profile time-window filtering remains separate
- leaves roadmap issue #3 open

Closes #71
Closes #70
